### PR TITLE
✨ ファビコン表示機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 日本の主要な技術系メディアの最新人気エントリーをお届けします。
 
 ---
-## 📰 Tech Blog Weekly
+## 💻 Tech Blog Weekly
 
 - [AWS Summit Japan 2025で登壇しました＆反省点 | ENECHANGE Developer Blog](https://tech.enechange.co.jp/entry/2025/06/28/223216)
 - [Fastlaneで外部連携された証明書をもとにプロビジョニングプロファイルを更新する方法（fastlane match import) | ENECHANGEのフィード](https://zenn.dev/enechange_blog/articles/fastlane-match-import-for-other-company-maintainer)
@@ -17,7 +17,7 @@
 - [20日で鍛える読解力：Day13｜「何が大事？」を見抜く“仕分け力”と“断捨離思考” | SHIFT Group 技術ブログ](https://note.shiftinc.jp/n/n0366bc21fed3)
 
 ---
-## 📰 Qiita
+## <img src="https://cdn.qiita.com/assets/favicons/public/production-c620d3e403342b1022967ba5e3db1aaa.ico" width="16" height="16" alt="Qiita"> Qiita
 
 - [【CSS】まだ width: 100% つかってるやついる⁉︎ いねぇよな⁉︎](https://qiita.com/degudegu2510/items/7079d76beeaa40c206d3?utm_campaign=popular_items&utm_medium=feed&utm_source=popular_items)
 - [Gemini CLIの"強み"を知る！ Gemini CLIとClaude Codeを比較してみた](https://qiita.com/kyuko/items/b7f7336057859f5c9b4f?utm_campaign=popular_items&utm_medium=feed&utm_source=popular_items)
@@ -31,7 +31,7 @@
 - [【入門】Vimを覚えたくない人のための最低限だけ学ぶVim](https://qiita.com/flowernotfound/items/cb8d51602bad909dae2a?utm_campaign=popular_items&utm_medium=feed&utm_source=popular_items)
 
 ---
-## 📰 Zenn
+## <img src="https://zenn.dev/favicon.ico" width="16" height="16" alt="Zenn"> Zenn
 
 - [o3 MCPでClaude Codeが最強の検索力を手に入れた](https://zenn.dev/yoshiko/articles/claude-code-with-o3)
 - [lsmcp - 汎用的な LSP の MCP サーバーを作った](https://zenn.dev/mizchi/articles/introduce-lsmcp)
@@ -45,16 +45,16 @@
 - [Gemini CLIやClaude Codeみたいなロゴを出力するoh-my-logoというツールを作りました](https://zenn.dev/shinshin86/articles/e02fac5d3ae75a)
 
 ---
-## 📰 はてなブックマーク - IT
+## <img src="https://b.hatena.ne.jp/favicon.ico" width="16" height="16" alt="はてなブックマーク - IT"> はてなブックマーク - IT
 
 - [【Obsidianの使い方が変わる】Gemini CLIは、あなたの思考に寄り添う「無料の執事」｜少し明るい高橋くん](https://note.com/chankostin/n/nb33ca6e289fa)
 - [【無料】グーグル神AIツール5選　「Google AI Studio」はこれがやばい (1/7)](https://ascii.jp/elem/000/004/286/4286792/)
 - [AIの世界も「フリーランチは終わった」になってきてるのでは - きしだのHatena](https://nowokay.hatenablog.com/entry/2025/06/26/224437)
 - [VueエンジニアがReactを触ってみた感想｜Yutori Otsu](https://note.com/yutori_otsu827/n/nf502e45cf14d)
 - [Anthropic、ワンクリックでローカルMCPサーバーをインストールできる「Desktop Extensions」をリリース | gihyo.jp](https://gihyo.jp/article/2025/06/claude-desktop-extensions)
+- [面接をして「この人優秀だな」と感じる人はどんな人か? - pospomeのプログラミング日記](https://www.pospome.work/entry/2025/06/28/151253)
 - [Claude Codeにコマンド一発でMCPサーバを簡単設定](https://zenn.dev/karaage0703/articles/3bd2957807f311)
 - [o3 MCPでClaude Codeが最強の検索力を手に入れた](https://zenn.dev/yoshiko/articles/claude-code-with-o3)
-- [面接をして「この人優秀だな」と感じる人はどんな人か? - pospomeのプログラミング日記](https://www.pospome.work/entry/2025/06/28/151253)
 - [【2025年】zip圧縮･展開(解凍) おすすめソフト12選まとめ＋解説【Win･Mac対応、文字化けよさらば！】 - Qiita](https://qiita.com/ko1nksm/items/b1e320f418614372c43e)
 - [AIネイティブ世代が実践してる。スマホでバイブコーディングする方法【Gemini-CLI】｜Holy_fox](https://note.com/holy_fox/n/nfe53492ac5dd)
 

--- a/fetch_news.py
+++ b/fetch_news.py
@@ -1,12 +1,24 @@
 import feedparser
 import datetime
 
-# 取得するRSSフィードのリスト
+# 取得するRSSフィードのリスト（ファビコン付き）
 FEEDS = {
-    "Tech Blog Weekly": "https://yamadashy.github.io/tech-blog-rss-feed/feeds/rss.xml",
-    "Qiita": "https://qiita.com/popular-items/feed",
-    "Zenn": "https://zenn.dev/feed",
-    "はてなブックマーク - IT": "http://b.hatena.ne.jp/hotentry/it.rss"
+    "Tech Blog Weekly": {
+        "url": "https://yamadashy.github.io/tech-blog-rss-feed/feeds/rss.xml",
+        "favicon": "💻"
+    },
+    "Qiita": {
+        "url": "https://qiita.com/popular-items/feed", 
+        "favicon": "https://cdn.qiita.com/assets/favicons/public/production-c620d3e403342b1022967ba5e3db1aaa.ico"
+    },
+    "Zenn": {
+        "url": "https://zenn.dev/feed",
+        "favicon": "https://zenn.dev/favicon.ico"
+    },
+    "はてなブックマーク - IT": {
+        "url": "http://b.hatena.ne.jp/hotentry/it.rss",
+        "favicon": "https://b.hatena.ne.jp/favicon.ico"
+    }
 }
 
 # 各フィードから取得する記事の件数
@@ -21,14 +33,21 @@ def fetch_feed_entries(feed_url):
         print(f"Error fetching feed from {feed_url}: {e}")
         return []
 
-def generate_markdown(all_entries):
+def generate_markdown(all_entries, feed_info):
     """取得したエントリーからMarkdownコンテンツを生成する"""
     today = datetime.date.today().isoformat()
     markdown = f"# 毎日のテックニュース ({today})\n\n"
     markdown += "日本の主要な技術系メディアの最新人気エントリーをお届けします。\n\n---\n"
 
     for feed_name, entries in all_entries.items():
-        markdown += f"## 📰 {feed_name}\n\n"
+        favicon = feed_info[feed_name]["favicon"]
+        if favicon.startswith("http"):
+            # ファビコンURLの場合
+            favicon_display = f'<img src="{favicon}" width="16" height="16" alt="{feed_name}">'
+        else:
+            # 絵文字の場合
+            favicon_display = favicon
+        markdown += f"## {favicon_display} {feed_name}\n\n"
         if not entries:
             markdown += "記事を取得できませんでした。\n"
         else:
@@ -43,12 +62,12 @@ def generate_markdown(all_entries):
 
 if __name__ == "__main__":
     all_entries = {}
-    for name, url in FEEDS.items():
+    for name, feed_info in FEEDS.items():
         print(f"Fetching entries from {name}...")
-        entries = fetch_feed_entries(url)
+        entries = fetch_feed_entries(feed_info["url"])
         all_entries[name] = entries
     
-    markdown_content = generate_markdown(all_entries)
+    markdown_content = generate_markdown(all_entries, FEEDS)
     
     with open("README.md", "w", encoding="utf-8") as f:
         f.write(markdown_content)


### PR DESCRIPTION
## Summary
- 各メディアのファビコンまたは絵文字を表示する機能を追加
- Tech Blog Weekly: 💻 絵文字でエンジニア感をアピール
- 他のメディア: 実際のファビコンでブランドアイデンティティを維持
- 絵文字とファビコンURLの混在表示に対応

## Changes
- `fetch_news.py`: ファビコン機能の実装
  - FEEDS辞書をファビコン情報付きの構造に変更
  - `generate_markdown`関数でファビコン表示ロジックを追加
  - 絵文字とHTTP URLの自動判別機能
- `README.md`: 新しい表示形式での出力結果

## Test plan
- [x] 各フィードからの記事取得が正常に動作
- [x] ファビコンと絵文字の混在表示が正常に動作
- [x] 生成されるMarkdownが適切にレンダリング
- [x] GitHub Actions自動実行への影響なし

## Before/After
**Before**: 📰 すべて同じ絵文字  
**After**: 💻 Tech Blog Weekly | 🖼️ 各サイトのファビコン

🤖 Generated with [Claude Code](https://claude.ai/code)