### PR TITLE
🔧 修正: GitHub Actionsでarchives/ディレクトリをコミット対象に追加

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -37,7 +37,7 @@ jobs:
         
     - name: Commit and push changes
       run: |
-        git add README.md
+        git add README.md archives/
         if git diff --staged --quiet; then
           echo "No changes to commit"
         else


### PR DESCRIPTION
## 変更内容
- GitHub ActionsワークフローでREADME.mdと合わせてarchives/ディレクトリもコミット対象に追加

## 変更理由
- アーカイブ機能が追加されたが、GitHub Actionsでarchives/ディレクトリがコミットされていなかった
- 日次実行時にアーカイブファイルとインデックスページが正しく保存されるように修正

## テスト方法
- GitHub Actionsの手動実行で動作確認
- archives/ディレクトリにファイルが正しくコミットされることを確認