### PR TITLE
✨ 機能追加: アーカイブ上書き時のメッセージ表示

### DIFF
--- a/fetch_news.py
+++ b/fetch_news.py
@@ -71,8 +71,13 @@ def save_to_archive(content, date_obj):
     archive_dir = Path(f"archives/{year}/{month}")
     archive_dir.mkdir(parents=True, exist_ok=True)
     
-    # ファイル保存
+    # ファイル保存（既存ファイルは上書き）
     archive_file = archive_dir / f"{date_str}.md"
+    if archive_file.exists():
+        print(f"Overwriting existing archive: {archive_file}")
+    else:
+        print(f"Creating new archive: {archive_file}")
+    
     with open(archive_file, "w", encoding="utf-8") as f:
         f.write(content)
     


### PR DESCRIPTION
## 変更内容
- 既存の日付のアーカイブファイルが存在する場合に上書きメッセージを表示
- 新規作成時と上書き時を明確に区別するメッセージを追加

## 変更理由
- 手動実行時に既存ファイルを上書きしているかどうかが分からなかった
- デバッグ時やテスト時に動作が明確になることで運用しやすくなる

## テスト方法
- 同じ日に複数回`python3 fetch_news.py`を実行
- 1回目：「Creating new archive」メッセージ
- 2回目：「Overwriting existing archive」メッセージが表示されることを確認