### PR TITLE
✨ 機能追加: RSSフィード配信機能

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -37,7 +37,7 @@ jobs:
         
     - name: Commit and push changes
       run: |
-        git add README.md archives/
+        git add README.md archives/ rss.xml
         if git diff --staged --quiet; then
           echo "No changes to commit"
         else

--- a/rss.xml
+++ b/rss.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+  <channel>
+    <title>毎日のテックニュース</title>
+    <link>https://unsolublesugar.github.io/daily-tech-news/</link>
+    <description>日本の主要な技術系メディアの最新人気エントリーを毎日お届けします</description>
+    <language>ja</language>
+    <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
+    <lastBuildDate>Sun, 29 Jun 2025 00:00:00 +0000</lastBuildDate>
+    <atom:link href="https://unsolublesugar.github.io/daily-tech-news/rss.xml" rel="self" type="application/rss+xml"/>
+    <item>
+      <title>💻 AWS Summit Japan 2025で登壇しました＆反省点 | ENECHANGE Developer Blog</title>
+      <link>https://tech.enechange.co.jp/entry/2025/06/28/223216</link>
+      <description>Tech Blog Weeklyからの記事: AWS Summit Japan 2025で登壇しました＆反省点 | ENECHANGE Developer Blog</description>
+      <guid>https://tech.enechange.co.jp/entry/2025/06/28/223216</guid>
+      <pubDate>Sat, 28 Jun 2025 13:32:16 +0000</pubDate>
+    </item>
+    <item>
+      <title>💻 Fastlaneで外部連携された証明書をもとにプロビジョニングプロファイルを更新する方法（fastlane match import) | ENECHANGEのフィード</title>
+      <link>https://zenn.dev/enechange_blog/articles/fastlane-match-import-for-other-company-maintainer</link>
+      <description>Tech Blog Weeklyからの記事: Fastlaneで外部連携された証明書をもとにプロビジョニングプロファイルを更新する方法（fastlane match import) | ENECHANGEのフィード</description>
+      <guid>https://zenn.dev/enechange_blog/articles/fastlane-match-import-for-other-company-maintainer</guid>
+      <pubDate>Sat, 28 Jun 2025 11:14:27 +0000</pubDate>
+    </item>
+    <item>
+      <title>💻 【イベントレポート】AWS Summit Japan 2025に初参加しました。 | APC 技術ブログ</title>
+      <link>https://techblog.ap-com.co.jp/entry/2025/06/28/174657</link>
+      <description>Tech Blog Weeklyからの記事: 【イベントレポート】AWS Summit Japan 2025に初参加しました。 | APC 技術ブログ</description>
+      <guid>https://techblog.ap-com.co.jp/entry/2025/06/28/174657</guid>
+      <pubDate>Sat, 28 Jun 2025 08:46:57 +0000</pubDate>
+    </item>
+    <item>
+      <title>💻 【AWS】AWS Summit Japan 2025 に参加してきました (セッション感想) | APC 技術ブログ</title>
+      <link>https://techblog.ap-com.co.jp/entry/2025/06/28/170210</link>
+      <description>Tech Blog Weeklyからの記事: 【AWS】AWS Summit Japan 2025 に参加してきました (セッション感想) | APC 技術ブログ</description>
+      <guid>https://techblog.ap-com.co.jp/entry/2025/06/28/170210</guid>
+      <pubDate>Sat, 28 Jun 2025 08:02:10 +0000</pubDate>
+    </item>
+    <item>
+      <title>💻 PHPカンファレンス2025 最速参加レポート | every Tech Blog</title>
+      <link>https://tech.every.tv/entry/2025/06/28/165655</link>
+      <description>Tech Blog Weeklyからの記事: PHPカンファレンス2025 最速参加レポート | every Tech Blog</description>
+      <guid>https://tech.every.tv/entry/2025/06/28/165655</guid>
+      <pubDate>Sat, 28 Jun 2025 07:56:55 +0000</pubDate>
+    </item>
+    <item>
+      <title>&lt;img src=&quot;https://cdn.qiita.com/assets/favicons/public/production-c620d3e403342b1022967ba5e3db1aaa.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;Qiita&quot;&gt; 【CSS】まだ width: 100% つかってるやついる⁉︎ いねぇよな⁉︎</title>
+      <link>https://qiita.com/degudegu2510/items/7079d76beeaa40c206d3?utm_campaign=popular_items&amp;utm_medium=feed&amp;utm_source=popular_items</link>
+      <description>Qiitaからの記事: 【CSS】まだ width: 100% つかってるやついる⁉︎ いねぇよな⁉︎</description>
+      <guid>https://qiita.com/degudegu2510/items/7079d76beeaa40c206d3?utm_campaign=popular_items&amp;utm_medium=feed&amp;utm_source=popular_items</guid>
+      <pubDate>Wed, 25 Jun 2025 23:09:34 +0000</pubDate>
+    </item>
+    <item>
+      <title>&lt;img src=&quot;https://cdn.qiita.com/assets/favicons/public/production-c620d3e403342b1022967ba5e3db1aaa.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;Qiita&quot;&gt; Gemini CLIの&quot;強み&quot;を知る！ Gemini CLIとClaude Codeを比較してみた</title>
+      <link>https://qiita.com/kyuko/items/b7f7336057859f5c9b4f?utm_campaign=popular_items&amp;utm_medium=feed&amp;utm_source=popular_items</link>
+      <description>Qiitaからの記事: Gemini CLIの&quot;強み&quot;を知る！ Gemini CLIとClaude Codeを比較してみた</description>
+      <guid>https://qiita.com/kyuko/items/b7f7336057859f5c9b4f?utm_campaign=popular_items&amp;utm_medium=feed&amp;utm_source=popular_items</guid>
+      <pubDate>Wed, 25 Jun 2025 18:59:24 +0000</pubDate>
+    </item>
+    <item>
+      <title>&lt;img src=&quot;https://cdn.qiita.com/assets/favicons/public/production-c620d3e403342b1022967ba5e3db1aaa.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;Qiita&quot;&gt; Gemini CLI をさっそく試してみた！</title>
+      <link>https://qiita.com/youtoy/items/fa5b696b055ed4a992ec?utm_campaign=popular_items&amp;utm_medium=feed&amp;utm_source=popular_items</link>
+      <description>Qiitaからの記事: Gemini CLI をさっそく試してみた！</description>
+      <guid>https://qiita.com/youtoy/items/fa5b696b055ed4a992ec?utm_campaign=popular_items&amp;utm_medium=feed&amp;utm_source=popular_items</guid>
+      <pubDate>Wed, 25 Jun 2025 14:26:10 +0000</pubDate>
+    </item>
+    <item>
+      <title>&lt;img src=&quot;https://cdn.qiita.com/assets/favicons/public/production-c620d3e403342b1022967ba5e3db1aaa.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;Qiita&quot;&gt; 10歳娘「凡ミスの多い人ってプログラマーに向いてるよね」</title>
+      <link>https://qiita.com/Yametaro/items/0b241519dc6b416474c5?utm_campaign=popular_items&amp;utm_medium=feed&amp;utm_source=popular_items</link>
+      <description>Qiitaからの記事: 10歳娘「凡ミスの多い人ってプログラマーに向いてるよね」</description>
+      <guid>https://qiita.com/Yametaro/items/0b241519dc6b416474c5?utm_campaign=popular_items&amp;utm_medium=feed&amp;utm_source=popular_items</guid>
+      <pubDate>Thu, 26 Jun 2025 23:03:17 +0000</pubDate>
+    </item>
+    <item>
+      <title>&lt;img src=&quot;https://cdn.qiita.com/assets/favicons/public/production-c620d3e403342b1022967ba5e3db1aaa.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;Qiita&quot;&gt; 【完全版】Gemini CLI チートシート - この記事で今日攻略！🚀</title>
+      <link>https://qiita.com/akira_papa_AI/items/15314a5bf1dd109053c2?utm_campaign=popular_items&amp;utm_medium=feed&amp;utm_source=popular_items</link>
+      <description>Qiitaからの記事: 【完全版】Gemini CLI チートシート - この記事で今日攻略！🚀</description>
+      <guid>https://qiita.com/akira_papa_AI/items/15314a5bf1dd109053c2?utm_campaign=popular_items&amp;utm_medium=feed&amp;utm_source=popular_items</guid>
+      <pubDate>Thu, 26 Jun 2025 19:58:23 +0000</pubDate>
+    </item>
+    <item>
+      <title>&lt;img src=&quot;https://zenn.dev/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;Zenn&quot;&gt; o3 MCPでClaude Codeが最強の検索力を手に入れた</title>
+      <link>https://zenn.dev/yoshiko/articles/claude-code-with-o3</link>
+      <description>Zennからの記事: o3 MCPでClaude Codeが最強の検索力を手に入れた</description>
+      <guid>https://zenn.dev/yoshiko/articles/claude-code-with-o3</guid>
+      <pubDate>Fri, 27 Jun 2025 13:23:10 +0000</pubDate>
+    </item>
+    <item>
+      <title>&lt;img src=&quot;https://zenn.dev/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;Zenn&quot;&gt; lsmcp - 汎用的な LSP の MCP サーバーを作った</title>
+      <link>https://zenn.dev/mizchi/articles/introduce-lsmcp</link>
+      <description>Zennからの記事: lsmcp - 汎用的な LSP の MCP サーバーを作った</description>
+      <guid>https://zenn.dev/mizchi/articles/introduce-lsmcp</guid>
+      <pubDate>Fri, 27 Jun 2025 08:05:08 +0000</pubDate>
+    </item>
+    <item>
+      <title>&lt;img src=&quot;https://zenn.dev/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;Zenn&quot;&gt; 【コーディング無し】既存 API サーバーを MCP サーバーに一瞬で変える方法</title>
+      <link>https://zenn.dev/microsoft/articles/expose-mcp-server-in-apim</link>
+      <description>Zennからの記事: 【コーディング無し】既存 API サーバーを MCP サーバーに一瞬で変える方法</description>
+      <guid>https://zenn.dev/microsoft/articles/expose-mcp-server-in-apim</guid>
+      <pubDate>Fri, 27 Jun 2025 07:37:18 +0000</pubDate>
+    </item>
+    <item>
+      <title>&lt;img src=&quot;https://zenn.dev/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;Zenn&quot;&gt; pg_duckdbとDuckLakeがもたらすOLAP統合の未来</title>
+      <link>https://zenn.dev/nttdata_tech/articles/tzkoba-pgduckdb-ducklake-202506</link>
+      <description>Zennからの記事: pg_duckdbとDuckLakeがもたらすOLAP統合の未来</description>
+      <guid>https://zenn.dev/nttdata_tech/articles/tzkoba-pgduckdb-ducklake-202506</guid>
+      <pubDate>Fri, 27 Jun 2025 06:10:22 +0000</pubDate>
+    </item>
+    <item>
+      <title>&lt;img src=&quot;https://zenn.dev/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;Zenn&quot;&gt; iOS開発の教科書(β版)</title>
+      <link>https://zenn.dev/st43/books/bb5ea67aa3de15</link>
+      <description>Zennからの記事: iOS開発の教科書(β版)</description>
+      <guid>https://zenn.dev/st43/books/bb5ea67aa3de15</guid>
+      <pubDate>Fri, 27 Jun 2025 04:59:15 +0000</pubDate>
+    </item>
+    <item>
+      <title>&lt;img src=&quot;https://b.hatena.ne.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;はてなブックマーク - IT&quot;&gt; 【Obsidianの使い方が変わる】Gemini CLIは、あなたの思考に寄り添う「無料の執事」｜少し明るい高橋くん</title>
+      <link>https://note.com/chankostin/n/nb33ca6e289fa</link>
+      <description>はてなブックマーク - ITからの記事: 【Obsidianの使い方が変わる】Gemini CLIは、あなたの思考に寄り添う「無料の執事」｜少し明るい高橋くん</description>
+      <guid>https://note.com/chankostin/n/nb33ca6e289fa</guid>
+      <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
+    </item>
+    <item>
+      <title>&lt;img src=&quot;https://b.hatena.ne.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;はてなブックマーク - IT&quot;&gt; 【無料】グーグル神AIツール5選　「Google AI Studio」はこれがやばい (1/7)</title>
+      <link>https://ascii.jp/elem/000/004/286/4286792/</link>
+      <description>はてなブックマーク - ITからの記事: 【無料】グーグル神AIツール5選　「Google AI Studio」はこれがやばい (1/7)</description>
+      <guid>https://ascii.jp/elem/000/004/286/4286792/</guid>
+      <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
+    </item>
+    <item>
+      <title>&lt;img src=&quot;https://b.hatena.ne.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;はてなブックマーク - IT&quot;&gt; AIの世界も「フリーランチは終わった」になってきてるのでは - きしだのHatena</title>
+      <link>https://nowokay.hatenablog.com/entry/2025/06/26/224437</link>
+      <description>はてなブックマーク - ITからの記事: AIの世界も「フリーランチは終わった」になってきてるのでは - きしだのHatena</description>
+      <guid>https://nowokay.hatenablog.com/entry/2025/06/26/224437</guid>
+      <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
+    </item>
+    <item>
+      <title>&lt;img src=&quot;https://b.hatena.ne.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;はてなブックマーク - IT&quot;&gt; VueエンジニアがReactを触ってみた感想｜Yutori Otsu</title>
+      <link>https://note.com/yutori_otsu827/n/nf502e45cf14d</link>
+      <description>はてなブックマーク - ITからの記事: VueエンジニアがReactを触ってみた感想｜Yutori Otsu</description>
+      <guid>https://note.com/yutori_otsu827/n/nf502e45cf14d</guid>
+      <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
+    </item>
+    <item>
+      <title>&lt;img src=&quot;https://b.hatena.ne.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;はてなブックマーク - IT&quot;&gt; 面接をして「この人優秀だな」と感じる人はどんな人か? - pospomeのプログラミング日記</title>
+      <link>https://www.pospome.work/entry/2025/06/28/151253</link>
+      <description>はてなブックマーク - ITからの記事: 面接をして「この人優秀だな」と感じる人はどんな人か? - pospomeのプログラミング日記</description>
+      <guid>https://www.pospome.work/entry/2025/06/28/151253</guid>
+      <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
## 変更内容
- 毎日のテックニュースをRSS XMLフィード形式で生成する機能を追加
- 各フィードから5件ずつ記事を抽出してRSSアイテムとして配信
- ファビコン表示、記事タイトル、リンク、公開日時を含む
- GitHub ActionsワークフローでRSSファイルも自動更新・コミット対象に追加

## 変更理由
- ユーザーがRSSリーダーでテックニュースを購読できるようになる
- GitHub Pagesで配信することで外部からアクセス可能なRSSフィードとして利用できる

## テスト方法
- `python3 fetch_news.py`実行後、rss.xmlファイルが生成されることを確認
- 生成されたRSSファイルの形式と内容を確認
- GitHub Actionsの手動実行でRSSファイルもコミットされることを確認

## 配信予定URL
https://unsolublesugar.github.io/daily-tech-news/rss.xml