### PR TITLE
✨ タイトルを「今日のテックニュース」に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 毎日のテックニュース (2025-06-29)
+# 今日のテックニュース (2025-06-29)
 
 📚 [過去のニュースを見る](archives/index.md) | 📡 [RSSフィードを購読](https://unsolublesugar.github.io/daily-tech-news/rss.xml) | 🎨 [カード表示版を見る](https://unsolublesugar.github.io/daily-tech-news/)
 

--- a/archives/2025/06/2025-06-29.md
+++ b/archives/2025/06/2025-06-29.md
@@ -1,4 +1,4 @@
-# 毎日のテックニュース (2025-06-29)
+# 今日のテックニュース (2025-06-29)
 
 📚 [過去のニュースを見る](archives/index.md) | 📡 [RSSフィードを購読](https://unsolublesugar.github.io/daily-tech-news/rss.xml) | 🎨 [カード表示版を見る](https://unsolublesugar.github.io/daily-tech-news/)
 

--- a/fetch_news.py
+++ b/fetch_news.py
@@ -118,7 +118,7 @@ def generate_html(all_entries, feed_info, date_str):
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>毎日のテックニュース ({date_str})</title>
+    <title>今日のテックニュース ({date_str})</title>
     <style>
         body {{
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -180,7 +180,7 @@ def generate_html(all_entries, feed_info, date_str):
     </style>
 </head>
 <body>
-    <h1>毎日のテックニュース ({date_str})</h1>
+    <h1>今日のテックニュース ({date_str})</h1>
     
     <p>📚 <a href="archives/index.html">過去のニュースを見る</a> | 📡 <a href="https://unsolublesugar.github.io/daily-tech-news/rss.xml">RSSフィードを購読</a></p>
     
@@ -238,7 +238,7 @@ def generate_html(all_entries, feed_info, date_str):
 
 def generate_markdown(all_entries, feed_info, date_str):
     """取得したエントリーからMarkdownコンテンツを生成する"""
-    markdown = f"# 毎日のテックニュース ({date_str})\n\n"
+    markdown = f"# 今日のテックニュース ({date_str})\n\n"
     markdown += "📚 [過去のニュースを見る](archives/index.md) | 📡 [RSSフィードを購読](https://unsolublesugar.github.io/daily-tech-news/rss.xml) | 🎨 [カード表示版を見る](https://unsolublesugar.github.io/daily-tech-news/)\n\n"
     markdown += "日本の主要な技術系メディアの最新人気エントリーをお届けします。\n\n"
     markdown += "## 🎨 カード表示版もあります\n\n"
@@ -373,7 +373,7 @@ def generate_rss_feed(all_entries, feed_info, date_obj):
     channel = ET.SubElement(rss, 'channel')
     
     # チャンネル情報
-    ET.SubElement(channel, 'title').text = '毎日のテックニュース'
+    ET.SubElement(channel, 'title').text = '今日のテックニュース'
     ET.SubElement(channel, 'link').text = 'https://unsolublesugar.github.io/daily-tech-news/'
     ET.SubElement(channel, 'description').text = '日本の主要な技術系メディアの最新人気エントリーを毎日お届けします'
     ET.SubElement(channel, 'language').text = 'ja'

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>毎日のテックニュース (2025-06-29)</title>
+    <title>今日のテックニュース (2025-06-29)</title>
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -65,7 +65,7 @@
     </style>
 </head>
 <body>
-    <h1>毎日のテックニュース (2025-06-29)</h1>
+    <h1>今日のテックニュース (2025-06-29)</h1>
     
     <p>📚 <a href="archives/index.html">過去のニュースを見る</a> | 📡 <a href="https://unsolublesugar.github.io/daily-tech-news/rss.xml">RSSフィードを購読</a></p>
     

--- a/rss.xml
+++ b/rss.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
   <channel>
-    <title>毎日のテックニュース</title>
+    <title>今日のテックニュース</title>
     <link>https://unsolublesugar.github.io/daily-tech-news/</link>
     <description>日本の主要な技術系メディアの最新人気エントリーを毎日お届けします</description>
     <language>ja</language>


### PR DESCRIPTION
## 変更内容
- 「毎日のテックニュース」から「今日のテックニュース」に変更
- README.md、index.html、RSSフィードすべてで統一
- より自然で正確なタイトル表現に改善

## 変更理由
- 朝7時に1回だけ更新するため「毎日」より「今日」の方が適切
- 日次更新の性質をより正確に表現
- ユーザーにとって理解しやすい表現に改善

## テスト方法
- [x] ローカルでのタイトル変更確認
- [x] README.md、index.html、RSSフィードでの統一確認
- [ ] GitHub Pages版での表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)