### PR TITLE
イベント系同名シリーズの重複除去機能 (closes #13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,15 +58,36 @@ The FEEDS dictionary in fetch_news.py contains the RSS URLs. Each feed is proces
 - **fixブランチ**: バグ修正用 (`fix/修正内容`)
 
 ### Development Workflow
-1. mainブランチに切り替え
-2. mainブランチの最新状況をpull
-3. mainブランチから新しいブランチを作成
-4. 変更を実装・テスト
-5. ブランチをリモートにプッシュ
-6. Pull Requestを作成
-7. レビュー・承認後にmainにマージ
+1. **Issue作成**: 作業開始前に必ずIssueを作成
+2. mainブランチに切り替え
+3. mainブランチの最新状況をpull
+4. Issueに対応するブランチを作成（ブランチ名にIssue番号を含める）
+5. 変更を実装・テスト
+6. ブランチをリモートにプッシュ
+7. Pull Requestを作成（IssueとPRを紐づける）
+8. レビュー・承認後にmainにマージ
 
-#### ブランチ作成手順
+### Issue作成ルール
+
+#### 作業開始前の必須手順
+```bash
+# Issue作成（機能追加の場合）
+gh issue create --title "✨ 機能名: 簡潔な説明" --body "詳細な説明" --label enhancement --assignee unsolublesugar
+
+# Issue作成（バグ修正の場合）
+gh issue create --title "🐛 バグ: 問題の説明" --body "再現手順と期待する動作" --label bug --assignee unsolublesugar
+
+# Issue作成（ドキュメント更新の場合）
+gh issue create --title "📚 ドキュメント: 更新内容" --body "更新理由と詳細" --label documentation --assignee unsolublesugar
+```
+
+#### Issue作成時の必須項目
+- **タイトル**: 絵文字プレフィックス + 簡潔な説明
+- **ラベル**: 作業内容に応じた適切なラベル設定
+- **アサイニー**: `unsolublesugar` (必須)
+- **本文**: 詳細な説明、受け入れ条件、実装方針など
+
+#### ブランチ作成手順（Issue作成後）
 ```bash
 # mainブランチに切り替え
 git checkout main
@@ -74,28 +95,33 @@ git checkout main
 # 最新状況をpull
 git pull origin main
 
-# 新しいブランチを作成・切り替え
-git checkout -b feature/機能名
+# Issue番号を含むブランチを作成・切り替え
+git checkout -b feature/issue-番号-機能名
 # または
-git checkout -b fix/修正内容
+git checkout -b fix/issue-番号-修正内容
+
+# 例：Issue #13に対応する場合
+git checkout -b feature/issue-13-event-deduplication
 ```
 
 ### Pull Request Creation Rules
 
-#### 基本コマンド
+#### 基本コマンド（Issue番号を含める）
 ```bash
-# 機能追加の場合
-gh pr create --title "✨ 機能名: 簡潔な説明" --assignee unsolublesugar --label enhancement --body "詳細な説明"
+# 機能追加の場合（Issue #13に対応）
+gh pr create --title "✨ 機能名: 簡潔な説明 (#13)" --assignee unsolublesugar --label enhancement --body "Closes #13\n\n詳細な説明"
 
-# バグ修正の場合  
-gh pr create --title "🐛 修正: 問題の説明" --assignee unsolublesugar --label bug --body "修正内容の詳細"
+# バグ修正の場合（Issue #14に対応）
+gh pr create --title "🐛 修正: 問題の説明 (#14)" --assignee unsolublesugar --label bug --body "Fixes #14\n\n修正内容の詳細"
 
-# ドキュメント更新の場合
-gh pr create --title "📚 ドキュメント: 更新内容" --assignee unsolublesugar --label documentation --body "更新理由と内容"
-
-# リファクタリングの場合
-gh pr create --title "♻️ リファクタリング: 対象範囲" --assignee unsolublesugar --label refactor --body "リファクタリング理由"
+# ドキュメント更新の場合（Issue #15に対応）
+gh pr create --title "📚 ドキュメント: 更新内容 (#15)" --assignee unsolublesugar --label documentation --body "Closes #15\n\n更新理由と内容"
 ```
+
+#### IssueとPRの紐づけ
+- **PRタイトル**: 末尾に `(#Issue番号)` を追加
+- **PR本文**: 先頭に `Closes #Issue番号` または `Fixes #Issue番号` を記載
+- これによりPRマージ時に自動でIssueがクローズされる
 
 #### 必須設定項目
 - **Assignee**: `unsolublesugar` (必須)

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ https://unsolublesugar.github.io/daily-tech-news/
 - [現状のAIが全然使い物にならないのは、非常に正しくて、そして間違っている。](https://anond.hatelabo.jp/20250628122821)
 - [プログラミング1ミリも分からない人がGemini CLI始めるまでの全手順（Win篇）｜ミヤマ｜営業部にいるデザイナー](https://note.com/mmmiyama/n/n9fa6839beb06)
 - [ターミナルを使う人は、とりあえず「mise」を入れておく時代。　　・・・を夢見て。](https://zenn.dev/dress_code/articles/a99ff13634bbe6)
-- [孫正義「4.8兆円で超知能（ASI）の胴元になる」株主総会書き起こし - エンジニアtype | 転職type](https://type.jp/et/feature/28743/)
-- [面接をして「この人優秀だな」と感じる人はどんな人か? - pospomeのプログラミング日記](https://www.pospome.work/entry/2025/06/28/151253)
+- [「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ](https://www.m3tech.blog/entry/2025/06/29/110000)
+- [Claude Codeを実際のプロジェクトにうまく適用させていくTips10選 - Qiita](https://qiita.com/nokonoko_1203/items/67f8692a0a3ca7e621f3)
 
 
 ---
@@ -72,11 +72,11 @@ https://unsolublesugar.github.io/daily-tech-news/
 ---
 ## <img src="https://dev.classmethod.jp/favicon.ico" width="16" height="16" alt="DevelopersIO"> DevelopersIO
 
+- [[作ってみた] レシートプリンター付きデバイスを使ってメモを出してみた](https://dev.classmethod.jp/articles/dev-receipt-printer-device-memo-output-maruto/)
 - [[アップデート] Amazon Route 53 Resolver Endpointがプライベートホストゾーンの DNS 委任をサポートするようになりました](https://dev.classmethod.jp/articles/amazon-route-53-resolver-endpoints-dns-delegation-private-hosted-zones/)
 - [[セッションレポート] AWS で実現する患者中心の医療サービス変革 ～デジタルトランスフォーメーションによる新たな医療の未来～（AWS-31）#AWSSummit](https://dev.classmethod.jp/articles/202506-aws-summit-2025-aws-31/)
 - [【ブースレポート】カメラで読み込んだ譜面をロボットアームで即興演奏するピアノボットが面白い #AWSSummit](https://dev.classmethod.jp/articles/awssummit-2025-pianobot-booth/)
 - [[セッションレポート] オープンテーブルフォーマットで実現する、大規模データ分析基盤の構築と運用 #AWSSummit](https://dev.classmethod.jp/articles/aws-summit-japan-2025-otf-data-analysis-basis-aws-47/)
-- [[アップデート] Amazon Q Developer のルールファイルがサードパーティプラットフォームでも使えるようになったので、Amazon Q Developer for GitHub でためしてみた](https://dev.classmethod.jp/articles/qdev-third-party-context-project-rules/)
 
 
 ---
@@ -123,10 +123,6 @@ https://unsolublesugar.github.io/daily-tech-news/
 - [北千住もくもく作業・勉強部屋](https://kitasenju-verystrong.connpass.com/event/360890/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [YUMEMI × やさしい Swift 勉強会 #547 #yumemi_grow](https://yasashii-swift.connpass.com/event/360729/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [朝活もくもく会 #23](https://zitox.connpass.com/event/360889/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
-- [朝活もくもく会 #22](https://zitox.connpass.com/event/360888/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
-- [朝活もくもく会 #21](https://zitox.connpass.com/event/360887/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
-- [朝活もくもく会 #20](https://zitox.connpass.com/event/360886/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
-- [朝活もくもく会 #19](https://zitox.connpass.com/event/360885/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [「競技プログラミングの鉄則」読書会 #11](https://study-group.connpass.com/event/360880/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [DevOpsDays ビデオ鑑賞会 #15](https://agiledevs.connpass.com/event/360881/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 

--- a/archives/2025/06/2025-06-29.md
+++ b/archives/2025/06/2025-06-29.md
@@ -17,7 +17,7 @@ https://unsolublesugar.github.io/daily-tech-news/
 **RSS URL:** `https://unsolublesugar.github.io/daily-tech-news/rss.xml`
 
 - 毎日JST 7:00に自動更新
-- 各フィードから5件ずつ厳選記事を配信
+- 技術記事は各フィードから5件、イベント情報は10件ずつ厳選配信
 
 ---
 ## 💻 Tech Blog Weekly
@@ -55,8 +55,8 @@ https://unsolublesugar.github.io/daily-tech-news/
 - [現状のAIが全然使い物にならないのは、非常に正しくて、そして間違っている。](https://anond.hatelabo.jp/20250628122821)
 - [プログラミング1ミリも分からない人がGemini CLI始めるまでの全手順（Win篇）｜ミヤマ｜営業部にいるデザイナー](https://note.com/mmmiyama/n/n9fa6839beb06)
 - [ターミナルを使う人は、とりあえず「mise」を入れておく時代。　　・・・を夢見て。](https://zenn.dev/dress_code/articles/a99ff13634bbe6)
-- [孫正義「4.8兆円で超知能（ASI）の胴元になる」株主総会書き起こし - エンジニアtype | 転職type](https://type.jp/et/feature/28743/)
-- [面接をして「この人優秀だな」と感じる人はどんな人か? - pospomeのプログラミング日記](https://www.pospome.work/entry/2025/06/28/151253)
+- [「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ](https://www.m3tech.blog/entry/2025/06/29/110000)
+- [Claude Codeを実際のプロジェクトにうまく適用させていくTips10選 - Qiita](https://qiita.com/nokonoko_1203/items/67f8692a0a3ca7e621f3)
 
 
 ---
@@ -72,11 +72,11 @@ https://unsolublesugar.github.io/daily-tech-news/
 ---
 ## <img src="https://dev.classmethod.jp/favicon.ico" width="16" height="16" alt="DevelopersIO"> DevelopersIO
 
+- [[作ってみた] レシートプリンター付きデバイスを使ってメモを出してみた](https://dev.classmethod.jp/articles/dev-receipt-printer-device-memo-output-maruto/)
 - [[アップデート] Amazon Route 53 Resolver Endpointがプライベートホストゾーンの DNS 委任をサポートするようになりました](https://dev.classmethod.jp/articles/amazon-route-53-resolver-endpoints-dns-delegation-private-hosted-zones/)
 - [[セッションレポート] AWS で実現する患者中心の医療サービス変革 ～デジタルトランスフォーメーションによる新たな医療の未来～（AWS-31）#AWSSummit](https://dev.classmethod.jp/articles/202506-aws-summit-2025-aws-31/)
 - [【ブースレポート】カメラで読み込んだ譜面をロボットアームで即興演奏するピアノボットが面白い #AWSSummit](https://dev.classmethod.jp/articles/awssummit-2025-pianobot-booth/)
 - [[セッションレポート] オープンテーブルフォーマットで実現する、大規模データ分析基盤の構築と運用 #AWSSummit](https://dev.classmethod.jp/articles/aws-summit-japan-2025-otf-data-analysis-basis-aws-47/)
-- [[アップデート] Amazon Q Developer のルールファイルがサードパーティプラットフォームでも使えるようになったので、Amazon Q Developer for GitHub でためしてみた](https://dev.classmethod.jp/articles/qdev-third-party-context-project-rules/)
 
 
 ---
@@ -123,10 +123,6 @@ https://unsolublesugar.github.io/daily-tech-news/
 - [北千住もくもく作業・勉強部屋](https://kitasenju-verystrong.connpass.com/event/360890/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [YUMEMI × やさしい Swift 勉強会 #547 #yumemi_grow](https://yasashii-swift.connpass.com/event/360729/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [朝活もくもく会 #23](https://zitox.connpass.com/event/360889/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
-- [朝活もくもく会 #22](https://zitox.connpass.com/event/360888/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
-- [朝活もくもく会 #21](https://zitox.connpass.com/event/360887/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
-- [朝活もくもく会 #20](https://zitox.connpass.com/event/360886/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
-- [朝活もくもく会 #19](https://zitox.connpass.com/event/360885/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [「競技プログラミングの鉄則」読書会 #11](https://study-group.connpass.com/event/360880/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [DevOpsDays ビデオ鑑賞会 #15](https://agiledevs.connpass.com/event/360881/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 

--- a/fetch_news.py
+++ b/fetch_news.py
@@ -148,8 +148,8 @@ def get_article_thumbnail(url, max_retries=2):
     
     return None  # 画像が見つからない場合
 
-def deduplicate_events(entries):
-    """イベント系エントリーの重複を除去（シリーズ番号違いを統合）"""
+def deduplicate_events(entries, target_count=10):
+    """イベント系エントリーの重複を除去（シリーズ番号違いを統合）し、目標件数を確保"""
     if not entries:
         return entries
     
@@ -207,6 +207,10 @@ def deduplicate_events(entries):
         if base_name not in seen_bases:
             deduplicated.append(event_groups[base_name])
             seen_bases.add(base_name)
+            
+            # 目標件数に達したら終了
+            if len(deduplicated) >= target_count:
+                break
     
     return deduplicated
 
@@ -291,7 +295,7 @@ def generate_html(all_entries, feed_info, date_str):
         <p><strong>RSS URL:</strong> <code>https://unsolublesugar.github.io/daily-tech-news/rss.xml</code></p>
         <ul>
             <li>毎日JST 7:00に自動更新</li>
-            <li>各フィードから5件ずつ厳選記事を配信</li>
+            <li>技術記事は各フィードから5件、イベント情報は10件ずつ厳選配信</li>
             <li>カード型レイアウトで読みやすく表示</li>
         </ul>
     </div>
@@ -352,7 +356,7 @@ def generate_markdown(all_entries, feed_info, date_str):
     markdown += "このニュースはRSSフィードでも配信しています。  \nお使いのRSSリーダーで以下のURLを購読してください：\n\n"
     markdown += "**RSS URL:** `https://unsolublesugar.github.io/daily-tech-news/rss.xml`\n\n"
     markdown += "- 毎日JST 7:00に自動更新\n"
-    markdown += "- 各フィードから5件ずつ厳選記事を配信\n\n---\n"
+    markdown += "- 技術記事は各フィードから5件、イベント情報は10件ずつ厳選配信\n\n---\n"
 
     for feed_name, entries in all_entries.items():
         favicon = feed_info[feed_name]["favicon"]

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
         <p><strong>RSS URL:</strong> <code>https://unsolublesugar.github.io/daily-tech-news/rss.xml</code></p>
         <ul>
             <li>毎日JST 7:00に自動更新</li>
-            <li>各フィードから5件ずつ厳選記事を配信</li>
+            <li>技術記事は各フィードから5件、イベント情報は10件ずつ厳選配信</li>
             <li>カード型レイアウトで読みやすく表示</li>
         </ul>
     </div>
@@ -250,20 +250,19 @@
             </div>
         </div>
     </a>
-    <a href="https://type.jp/et/feature/28743/" class="card">
+    <a href="https://www.m3tech.blog/entry/2025/06/29/110000" class="card">
         <div class="card-content">
-            <img src="https://type.jp/et/feature/wp-content/uploads/2025/06/e711f96bdd6c98f06dfe281b9b95a9ae.jpg" width="120" height="90" alt="孫正義「4.8兆円で超知能（ASI）の胴元になる」株主総会書き起こし - エンジニアtype | 転職type" class="card-image">
+            <img src="https://cdn.image.st-hatena.com/image/scale/ac19f8b37b13e1f29fe12c92d6ae177534e24840/backend=imagemagick;version=1;width=1300/https%3A%2F%2Fcdn-ak.f.st-hatena.com%2Fimages%2Ffotolife%2Fm%2Fm3tech%2F20250629%2F20250629110005.png" width="120" height="90" alt="「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ" class="card-image">
             <div class="card-text">
-                <h4 class="card-title">孫正義「4.8兆円で超知能（ASI）の胴元になる」株主総会書き起こし - エンジニアtype | 転職type</h4>
+                <h4 class="card-title">「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ</h4>
                 <p class="card-source">はてなブックマーク - IT（人気）</p>
             </div>
         </div>
     </a>
-    <a href="https://www.pospome.work/entry/2025/06/28/151253" class="card">
+    <a href="https://qiita.com/nokonoko_1203/items/67f8692a0a3ca7e621f3" class="card">
         <div class="card-content">
-            <img src="https://cdn.image.st-hatena.com/image/square/664b9cdb83f1a563164712ec805f1b5c56f76fa9/backend=imagemagick;height=128;version=1;width=128/https%3A%2F%2Fcdn.user.blog.st-hatena.com%2Fcustom_blog_icon%2F72897128%2F1514228874850668" width="120" height="90" alt="面接をして「この人優秀だな」と感じる人はどんな人か? - pospomeのプログラミング日記" class="card-image">
             <div class="card-text">
-                <h4 class="card-title">面接をして「この人優秀だな」と感じる人はどんな人か? - pospomeのプログラミング日記</h4>
+                <h4 class="card-title">Claude Codeを実際のプロジェクトにうまく適用させていくTips10選 - Qiita</h4>
                 <p class="card-source">はてなブックマーク - IT（人気）</p>
             </div>
         </div>
@@ -317,6 +316,15 @@
     </a>
     <hr>
     <h2><img src="https://dev.classmethod.jp/favicon.ico" width="16" height="16" alt="DevelopersIO"> DevelopersIO</h2>
+    <a href="https://dev.classmethod.jp/articles/dev-receipt-printer-device-memo-output-maruto/" class="card">
+        <div class="card-content">
+            <img src="https://devio2024-media.developers.io/image/upload/v1751177910/user-gen-eyecatch/nso1641smcalsp5jcczd.jpg" width="120" height="90" alt="[作ってみた] レシートプリンター付きデバイスを使ってメモを出してみた" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">[作ってみた] レシートプリンター付きデバイスを使ってメモを出してみた</h4>
+                <p class="card-source">DevelopersIO</p>
+            </div>
+        </div>
+    </a>
     <a href="https://dev.classmethod.jp/articles/amazon-route-53-resolver-endpoints-dns-delegation-private-hosted-zones/" class="card">
         <div class="card-content">
             <img src="https://dev.classmethod.jp/img/burger.svg" width="120" height="90" alt="[アップデート] Amazon Route 53 Resolver Endpointがプライベートホストゾーンの DNS 委任をサポートするようになりました" class="card-image">
@@ -349,15 +357,6 @@
             <img src="https://images.ctfassets.net/ct0aopd36mqt/IpyxwdJt9befE2LRbgxQg/028ee4834e885c77086d6c53a87f1c10/eyecatch_awssummitjapan2025_sessionj_1200x630.jpg" width="120" height="90" alt="[セッションレポート] オープンテーブルフォーマットで実現する、大規模データ分析基盤の構築と運用 #AWSSummit" class="card-image">
             <div class="card-text">
                 <h4 class="card-title">[セッションレポート] オープンテーブルフォーマットで実現する、大規模データ分析基盤の構築と運用 #AWSSummit</h4>
-                <p class="card-source">DevelopersIO</p>
-            </div>
-        </div>
-    </a>
-    <a href="https://dev.classmethod.jp/articles/qdev-third-party-context-project-rules/" class="card">
-        <div class="card-content">
-            <img src="https://dev.classmethod.jp/img/burger.svg" width="120" height="90" alt="[アップデート] Amazon Q Developer のルールファイルがサードパーティプラットフォームでも使えるようになったので、Amazon Q Developer for GitHub でためしてみた" class="card-image">
-            <div class="card-text">
-                <h4 class="card-title">[アップデート] Amazon Q Developer のルールファイルがサードパーティプラットフォームでも使えるようになったので、Amazon Q Developer for GitHub でためしてみた</h4>
                 <p class="card-source">DevelopersIO</p>
             </div>
         </div>
@@ -557,42 +556,6 @@
             <img src="https://media.connpass.com/thumbs/1b/7e/1b7e6b519302c036b789295c4c0ada8c.png" width="120" height="90" alt="朝活もくもく会 #23" class="card-image">
             <div class="card-text">
                 <h4 class="card-title">朝活もくもく会 #23</h4>
-                <p class="card-source">connpass - イベント</p>
-            </div>
-        </div>
-    </a>
-    <a href="https://zitox.connpass.com/event/360888/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom" class="card">
-        <div class="card-content">
-            <img src="https://media.connpass.com/thumbs/1b/7e/1b7e6b519302c036b789295c4c0ada8c.png" width="120" height="90" alt="朝活もくもく会 #22" class="card-image">
-            <div class="card-text">
-                <h4 class="card-title">朝活もくもく会 #22</h4>
-                <p class="card-source">connpass - イベント</p>
-            </div>
-        </div>
-    </a>
-    <a href="https://zitox.connpass.com/event/360887/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom" class="card">
-        <div class="card-content">
-            <img src="https://media.connpass.com/thumbs/1b/7e/1b7e6b519302c036b789295c4c0ada8c.png" width="120" height="90" alt="朝活もくもく会 #21" class="card-image">
-            <div class="card-text">
-                <h4 class="card-title">朝活もくもく会 #21</h4>
-                <p class="card-source">connpass - イベント</p>
-            </div>
-        </div>
-    </a>
-    <a href="https://zitox.connpass.com/event/360886/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom" class="card">
-        <div class="card-content">
-            <img src="https://media.connpass.com/thumbs/1b/7e/1b7e6b519302c036b789295c4c0ada8c.png" width="120" height="90" alt="朝活もくもく会 #20" class="card-image">
-            <div class="card-text">
-                <h4 class="card-title">朝活もくもく会 #20</h4>
-                <p class="card-source">connpass - イベント</p>
-            </div>
-        </div>
-    </a>
-    <a href="https://zitox.connpass.com/event/360885/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom" class="card">
-        <div class="card-content">
-            <img src="https://media.connpass.com/thumbs/1b/7e/1b7e6b519302c036b789295c4c0ada8c.png" width="120" height="90" alt="朝活もくもく会 #19" class="card-image">
-            <div class="card-text">
-                <h4 class="card-title">朝活もくもく会 #19</h4>
                 <p class="card-source">connpass - イベント</p>
             </div>
         </div>

--- a/rss.xml
+++ b/rss.xml
@@ -135,17 +135,17 @@
       <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
     </item>
     <item>
-      <title>&lt;img src=&quot;https://b.hatena.ne.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;はてなブックマーク - IT（人気）&quot;&gt; 孫正義「4.8兆円で超知能（ASI）の胴元になる」株主総会書き起こし - エンジニアtype | 転職type</title>
-      <link>https://type.jp/et/feature/28743/</link>
-      <description>はてなブックマーク - IT（人気）からの記事: 孫正義「4.8兆円で超知能（ASI）の胴元になる」株主総会書き起こし - エンジニアtype | 転職type</description>
-      <guid>https://type.jp/et/feature/28743/</guid>
+      <title>&lt;img src=&quot;https://b.hatena.ne.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;はてなブックマーク - IT（人気）&quot;&gt; 「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ</title>
+      <link>https://www.m3tech.blog/entry/2025/06/29/110000</link>
+      <description>はてなブックマーク - IT（人気）からの記事: 「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ</description>
+      <guid>https://www.m3tech.blog/entry/2025/06/29/110000</guid>
       <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
     </item>
     <item>
-      <title>&lt;img src=&quot;https://b.hatena.ne.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;はてなブックマーク - IT（人気）&quot;&gt; 面接をして「この人優秀だな」と感じる人はどんな人か? - pospomeのプログラミング日記</title>
-      <link>https://www.pospome.work/entry/2025/06/28/151253</link>
-      <description>はてなブックマーク - IT（人気）からの記事: 面接をして「この人優秀だな」と感じる人はどんな人か? - pospomeのプログラミング日記</description>
-      <guid>https://www.pospome.work/entry/2025/06/28/151253</guid>
+      <title>&lt;img src=&quot;https://b.hatena.ne.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;はてなブックマーク - IT（人気）&quot;&gt; Claude Codeを実際のプロジェクトにうまく適用させていくTips10選 - Qiita</title>
+      <link>https://qiita.com/nokonoko_1203/items/67f8692a0a3ca7e621f3</link>
+      <description>はてなブックマーク - IT（人気）からの記事: Claude Codeを実際のプロジェクトにうまく適用させていくTips10選 - Qiita</description>
+      <guid>https://qiita.com/nokonoko_1203/items/67f8692a0a3ca7e621f3</guid>
       <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
     </item>
     <item>
@@ -184,6 +184,13 @@
       <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
     </item>
     <item>
+      <title>&lt;img src=&quot;https://dev.classmethod.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;DevelopersIO&quot;&gt; [作ってみた] レシートプリンター付きデバイスを使ってメモを出してみた</title>
+      <link>https://dev.classmethod.jp/articles/dev-receipt-printer-device-memo-output-maruto/</link>
+      <description>DevelopersIOからの記事: [作ってみた] レシートプリンター付きデバイスを使ってメモを出してみた</description>
+      <guid>https://dev.classmethod.jp/articles/dev-receipt-printer-device-memo-output-maruto/</guid>
+      <pubDate>Sun, 29 Jun 2025 06:22:20 +0000</pubDate>
+    </item>
+    <item>
       <title>&lt;img src=&quot;https://dev.classmethod.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;DevelopersIO&quot;&gt; [アップデート] Amazon Route 53 Resolver Endpointがプライベートホストゾーンの DNS 委任をサポートするようになりました</title>
       <link>https://dev.classmethod.jp/articles/amazon-route-53-resolver-endpoints-dns-delegation-private-hosted-zones/</link>
       <description>DevelopersIOからの記事: [アップデート] Amazon Route 53 Resolver Endpointがプライベートホストゾーンの DNS 委任をサポートするようになりました</description>
@@ -210,13 +217,6 @@
       <description>DevelopersIOからの記事: [セッションレポート] オープンテーブルフォーマットで実現する、大規模データ分析基盤の構築と運用 #AWSSummit</description>
       <guid>https://dev.classmethod.jp/articles/aws-summit-japan-2025-otf-data-analysis-basis-aws-47/</guid>
       <pubDate>Sun, 29 Jun 2025 04:13:32 +0000</pubDate>
-    </item>
-    <item>
-      <title>&lt;img src=&quot;https://dev.classmethod.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;DevelopersIO&quot;&gt; [アップデート] Amazon Q Developer のルールファイルがサードパーティプラットフォームでも使えるようになったので、Amazon Q Developer for GitHub でためしてみた</title>
-      <link>https://dev.classmethod.jp/articles/qdev-third-party-context-project-rules/</link>
-      <description>DevelopersIOからの記事: [アップデート] Amazon Q Developer のルールファイルがサードパーティプラットフォームでも使えるようになったので、Amazon Q Developer for GitHub でためしてみた</description>
-      <guid>https://dev.classmethod.jp/articles/qdev-third-party-context-project-rules/</guid>
-      <pubDate>Sat, 28 Jun 2025 21:18:16 +0000</pubDate>
     </item>
     <item>
       <title>&lt;img src=&quot;https://gihyo.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;gihyo.jp&quot;&gt; Anthropic、ワンクリックでローカルMCPサーバーをインストールできる「Desktop Extensions」をリリース</title>
@@ -364,34 +364,6 @@
       <description>connpass - イベントからの記事: 朝活もくもく会 #23</description>
       <guid>https://zitox.connpass.com/event/360889/?utm_campaign=recent_events&amp;utm_source=feed&amp;utm_medium=atom</guid>
       <pubDate>Sun, 29 Jun 2025 03:54:24 +0000</pubDate>
-    </item>
-    <item>
-      <title>&lt;img src=&quot;https://connpass.com/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;connpass - イベント&quot;&gt; 朝活もくもく会 #22</title>
-      <link>https://zitox.connpass.com/event/360888/?utm_campaign=recent_events&amp;utm_source=feed&amp;utm_medium=atom</link>
-      <description>connpass - イベントからの記事: 朝活もくもく会 #22</description>
-      <guid>https://zitox.connpass.com/event/360888/?utm_campaign=recent_events&amp;utm_source=feed&amp;utm_medium=atom</guid>
-      <pubDate>Sun, 29 Jun 2025 03:53:56 +0000</pubDate>
-    </item>
-    <item>
-      <title>&lt;img src=&quot;https://connpass.com/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;connpass - イベント&quot;&gt; 朝活もくもく会 #21</title>
-      <link>https://zitox.connpass.com/event/360887/?utm_campaign=recent_events&amp;utm_source=feed&amp;utm_medium=atom</link>
-      <description>connpass - イベントからの記事: 朝活もくもく会 #21</description>
-      <guid>https://zitox.connpass.com/event/360887/?utm_campaign=recent_events&amp;utm_source=feed&amp;utm_medium=atom</guid>
-      <pubDate>Sun, 29 Jun 2025 03:53:27 +0000</pubDate>
-    </item>
-    <item>
-      <title>&lt;img src=&quot;https://connpass.com/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;connpass - イベント&quot;&gt; 朝活もくもく会 #20</title>
-      <link>https://zitox.connpass.com/event/360886/?utm_campaign=recent_events&amp;utm_source=feed&amp;utm_medium=atom</link>
-      <description>connpass - イベントからの記事: 朝活もくもく会 #20</description>
-      <guid>https://zitox.connpass.com/event/360886/?utm_campaign=recent_events&amp;utm_source=feed&amp;utm_medium=atom</guid>
-      <pubDate>Sun, 29 Jun 2025 03:53:00 +0000</pubDate>
-    </item>
-    <item>
-      <title>&lt;img src=&quot;https://connpass.com/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;connpass - イベント&quot;&gt; 朝活もくもく会 #19</title>
-      <link>https://zitox.connpass.com/event/360885/?utm_campaign=recent_events&amp;utm_source=feed&amp;utm_medium=atom</link>
-      <description>connpass - イベントからの記事: 朝活もくもく会 #19</description>
-      <guid>https://zitox.connpass.com/event/360885/?utm_campaign=recent_events&amp;utm_source=feed&amp;utm_medium=atom</guid>
-      <pubDate>Sun, 29 Jun 2025 03:52:30 +0000</pubDate>
     </item>
     <item>
       <title>&lt;img src=&quot;https://connpass.com/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;connpass - イベント&quot;&gt; 「競技プログラミングの鉄則」読書会 #11</title>


### PR DESCRIPTION
## Summary
- イベントフィードで同一シリーズの重複エントリーを除去する機能を実装
- 正規表現パターンで「朝活もくもく会 #19-#23」等のシリーズ番号を検出
- 最新のエントリーを優先して1シリーズあたり1エントリーに統合
- 重複除去後も可能な限り10件のイベント情報を確保するよう調整
- HTMLとMarkdownの説明文を「技術記事5件、イベント情報10件」に修正

## Test plan
- [x] fetch_news.py の実行で重複除去が正常に動作することを確認
- [x] connpassフィードで朝活もくもく会が1エントリーのみになることを確認
- [x] 生成されたHTML、RSS、Markdownで重複が除去されていることを確認
- [x] 説明文が正確に更新されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)