### PR TITLE
✨ GitHub Pagesフッター: 運営者情報とリポジトリリンクを追加 (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ https://unsolublesugar.github.io/daily-tech-news/
 ---
 ## <img src="https://dev.classmethod.jp/favicon.ico" width="16" height="16" alt="DevelopersIO"> DevelopersIO
 
+- [Dagsterとdbt CoreをECS on Fargateで構築する](https://dev.classmethod.jp/articles/dagster-dbt-core-ecs-sample/)
 - [[作ってみた] レシートプリンター付きデバイスを使ってメモを出してみた](https://dev.classmethod.jp/articles/dev-receipt-printer-device-memo-output-maruto/)
 - [[アップデート] Amazon Route 53 Resolver Endpointがプライベートホストゾーンの DNS 委任をサポートするようになりました](https://dev.classmethod.jp/articles/amazon-route-53-resolver-endpoints-dns-delegation-private-hosted-zones/)
 - [[セッションレポート] AWS で実現する患者中心の医療サービス変革 ～デジタルトランスフォーメーションによる新たな医療の未来～（AWS-31）#AWSSummit](https://dev.classmethod.jp/articles/202506-aws-summit-2025-aws-31/)
 - [【ブースレポート】カメラで読み込んだ譜面をロボットアームで即興演奏するピアノボットが面白い #AWSSummit](https://dev.classmethod.jp/articles/awssummit-2025-pianobot-booth/)
-- [[セッションレポート] オープンテーブルフォーマットで実現する、大規模データ分析基盤の構築と運用 #AWSSummit](https://dev.classmethod.jp/articles/aws-summit-japan-2025-otf-data-analysis-basis-aws-47/)
 
 
 ---

--- a/archives/2025/06/2025-06-29.md
+++ b/archives/2025/06/2025-06-29.md
@@ -72,11 +72,11 @@ https://unsolublesugar.github.io/daily-tech-news/
 ---
 ## <img src="https://dev.classmethod.jp/favicon.ico" width="16" height="16" alt="DevelopersIO"> DevelopersIO
 
+- [Dagsterとdbt CoreをECS on Fargateで構築する](https://dev.classmethod.jp/articles/dagster-dbt-core-ecs-sample/)
 - [[作ってみた] レシートプリンター付きデバイスを使ってメモを出してみた](https://dev.classmethod.jp/articles/dev-receipt-printer-device-memo-output-maruto/)
 - [[アップデート] Amazon Route 53 Resolver Endpointがプライベートホストゾーンの DNS 委任をサポートするようになりました](https://dev.classmethod.jp/articles/amazon-route-53-resolver-endpoints-dns-delegation-private-hosted-zones/)
 - [[セッションレポート] AWS で実現する患者中心の医療サービス変革 ～デジタルトランスフォーメーションによる新たな医療の未来～（AWS-31）#AWSSummit](https://dev.classmethod.jp/articles/202506-aws-summit-2025-aws-31/)
 - [【ブースレポート】カメラで読み込んだ譜面をロボットアームで即興演奏するピアノボットが面白い #AWSSummit](https://dev.classmethod.jp/articles/awssummit-2025-pianobot-booth/)
-- [[セッションレポート] オープンテーブルフォーマットで実現する、大規模データ分析基盤の構築と運用 #AWSSummit](https://dev.classmethod.jp/articles/aws-summit-japan-2025-otf-data-analysis-basis-aws-47/)
 
 
 ---

--- a/fetch_news.py
+++ b/fetch_news.py
@@ -280,6 +280,21 @@ def generate_html(all_entries, feed_info, date_str):
             border-radius: 8px;
             margin: 20px 0;
         }}
+        .footer {{
+            margin-top: 40px;
+            padding: 20px 0;
+            border-top: 1px solid #e1e5e9;
+            text-align: center;
+            font-size: 14px;
+            color: #656d76;
+        }}
+        .footer a {{
+            color: #0969da;
+            text-decoration: none;
+        }}
+        .footer a:hover {{
+            text-decoration: underline;
+        }}
     </style>
 </head>
 <body>
@@ -340,6 +355,10 @@ def generate_html(all_entries, feed_info, date_str):
         html += "    <hr>\n"
     
     html += """
+    <div class="footer">
+        <p>🚀 運営者: <a href="https://x.com/unsoluble_sugar" target="_blank" rel="noopener">@unsoluble_sugar</a> | 
+        📁 <a href="https://github.com/unsolublesugar/daily-tech-news" target="_blank" rel="noopener">GitHub Repository</a></p>
+    </div>
 </body>
 </html>"""
     

--- a/index.html
+++ b/index.html
@@ -62,6 +62,21 @@
             border-radius: 8px;
             margin: 20px 0;
         }
+        .footer {
+            margin-top: 40px;
+            padding: 20px 0;
+            border-top: 1px solid #e1e5e9;
+            text-align: center;
+            font-size: 14px;
+            color: #656d76;
+        }
+        .footer a {
+            color: #0969da;
+            text-decoration: none;
+        }
+        .footer a:hover {
+            text-decoration: underline;
+        }
     </style>
 </head>
 <body>
@@ -316,6 +331,15 @@
     </a>
     <hr>
     <h2><img src="https://dev.classmethod.jp/favicon.ico" width="16" height="16" alt="DevelopersIO"> DevelopersIO</h2>
+    <a href="https://dev.classmethod.jp/articles/dagster-dbt-core-ecs-sample/" class="card">
+        <div class="card-content">
+            <img src="https://devio2024-media.developers.io/image/upload/v1751177666/user-gen-eyecatch/hmskqgbszs1ltpgomkkn.png" width="120" height="90" alt="Dagsterとdbt CoreをECS on Fargateで構築する" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">Dagsterとdbt CoreをECS on Fargateで構築する</h4>
+                <p class="card-source">DevelopersIO</p>
+            </div>
+        </div>
+    </a>
     <a href="https://dev.classmethod.jp/articles/dev-receipt-printer-device-memo-output-maruto/" class="card">
         <div class="card-content">
             <img src="https://devio2024-media.developers.io/image/upload/v1751177910/user-gen-eyecatch/nso1641smcalsp5jcczd.jpg" width="120" height="90" alt="[作ってみた] レシートプリンター付きデバイスを使ってメモを出してみた" class="card-image">
@@ -348,15 +372,6 @@
             <img src="https://devio2024-media.developers.io/image/upload/v1751170204/user-gen-eyecatch/sdv2cmaj4ss7ucafcsfj.jpg" width="120" height="90" alt="【ブースレポート】カメラで読み込んだ譜面をロボットアームで即興演奏するピアノボットが面白い #AWSSummit" class="card-image">
             <div class="card-text">
                 <h4 class="card-title">【ブースレポート】カメラで読み込んだ譜面をロボットアームで即興演奏するピアノボットが面白い #AWSSummit</h4>
-                <p class="card-source">DevelopersIO</p>
-            </div>
-        </div>
-    </a>
-    <a href="https://dev.classmethod.jp/articles/aws-summit-japan-2025-otf-data-analysis-basis-aws-47/" class="card">
-        <div class="card-content">
-            <img src="https://images.ctfassets.net/ct0aopd36mqt/IpyxwdJt9befE2LRbgxQg/028ee4834e885c77086d6c53a87f1c10/eyecatch_awssummitjapan2025_sessionj_1200x630.jpg" width="120" height="90" alt="[セッションレポート] オープンテーブルフォーマットで実現する、大規模データ分析基盤の構築と運用 #AWSSummit" class="card-image">
-            <div class="card-text">
-                <h4 class="card-title">[セッションレポート] オープンテーブルフォーマットで実現する、大規模データ分析基盤の構築と運用 #AWSSummit</h4>
                 <p class="card-source">DevelopersIO</p>
             </div>
         </div>
@@ -515,7 +530,7 @@
     </a>
     <a href="https://www.infoq.com/jp/news/2025/06/cisco-jarvis-ai-assistant/?utm_campaign=infoq_content&utm_source=infoq&utm_medium=feed&utm_term=global" class="card">
         <div class="card-content">
-            <img src="https://cdn.infoq.com/statics_s1_20250605075448/styles/static/images/logo/logo-big.jpg" width="120" height="90" alt="CiscoがJARVISを発表：プラットフォームエンジニアリングチームのためのAIアシスタント" class="card-image">
+            <img src="https://cdn.infoq.com/statics_s2_20250605075544/styles/static/images/logo/logo-big.jpg" width="120" height="90" alt="CiscoがJARVISを発表：プラットフォームエンジニアリングチームのためのAIアシスタント" class="card-image">
             <div class="card-text">
                 <h4 class="card-title">CiscoがJARVISを発表：プラットフォームエンジニアリングチームのためのAIアシスタント</h4>
                 <p class="card-source">InfoQ Japan</p>
@@ -719,5 +734,9 @@
     </a>
     <hr>
 
+    <div class="footer">
+        <p>🚀 運営者: <a href="https://x.com/unsoluble_sugar" target="_blank" rel="noopener">@unsoluble_sugar</a> | 
+        📁 <a href="https://github.com/unsolublesugar/daily-tech-news" target="_blank" rel="noopener">GitHub Repository</a></p>
+    </div>
 </body>
 </html>

--- a/rss.xml
+++ b/rss.xml
@@ -184,6 +184,13 @@
       <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
     </item>
     <item>
+      <title>&lt;img src=&quot;https://dev.classmethod.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;DevelopersIO&quot;&gt; Dagsterとdbt CoreをECS on Fargateで構築する</title>
+      <link>https://dev.classmethod.jp/articles/dagster-dbt-core-ecs-sample/</link>
+      <description>DevelopersIOからの記事: Dagsterとdbt CoreをECS on Fargateで構築する</description>
+      <guid>https://dev.classmethod.jp/articles/dagster-dbt-core-ecs-sample/</guid>
+      <pubDate>Sun, 29 Jun 2025 06:27:55 +0000</pubDate>
+    </item>
+    <item>
       <title>&lt;img src=&quot;https://dev.classmethod.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;DevelopersIO&quot;&gt; [作ってみた] レシートプリンター付きデバイスを使ってメモを出してみた</title>
       <link>https://dev.classmethod.jp/articles/dev-receipt-printer-device-memo-output-maruto/</link>
       <description>DevelopersIOからの記事: [作ってみた] レシートプリンター付きデバイスを使ってメモを出してみた</description>
@@ -210,13 +217,6 @@
       <description>DevelopersIOからの記事: 【ブースレポート】カメラで読み込んだ譜面をロボットアームで即興演奏するピアノボットが面白い #AWSSummit</description>
       <guid>https://dev.classmethod.jp/articles/awssummit-2025-pianobot-booth/</guid>
       <pubDate>Sun, 29 Jun 2025 04:25:23 +0000</pubDate>
-    </item>
-    <item>
-      <title>&lt;img src=&quot;https://dev.classmethod.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;DevelopersIO&quot;&gt; [セッションレポート] オープンテーブルフォーマットで実現する、大規模データ分析基盤の構築と運用 #AWSSummit</title>
-      <link>https://dev.classmethod.jp/articles/aws-summit-japan-2025-otf-data-analysis-basis-aws-47/</link>
-      <description>DevelopersIOからの記事: [セッションレポート] オープンテーブルフォーマットで実現する、大規模データ分析基盤の構築と運用 #AWSSummit</description>
-      <guid>https://dev.classmethod.jp/articles/aws-summit-japan-2025-otf-data-analysis-basis-aws-47/</guid>
-      <pubDate>Sun, 29 Jun 2025 04:13:32 +0000</pubDate>
     </item>
     <item>
       <title>&lt;img src=&quot;https://gihyo.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;gihyo.jp&quot;&gt; Anthropic、ワンクリックでローカルMCPサーバーをインストールできる「Desktop Extensions」をリリース</title>


### PR DESCRIPTION
Closes #15

## 変更内容
- GitHub Pagesサイト（index.html）にフッター部分を追加
- 運営者Twitter (@unsoluble_sugar) とGitHubリポジトリへのリンクを配置
- 新しいタブで開くセキュアなリンク設定

## 変更理由
GitHub Pagesサイトに運営者情報とソースコードへのアクセスを提供することで、透明性を向上させユーザーの信頼を獲得するため

## 技術的詳細
- フッター用CSSスタイルの追加（中央揃え、境界線、適切なスペーシング）
- HTML生成時にフッター要素を追加
- `target="_blank"` と `rel="noopener"` でセキュアなリンク

## テスト結果
- [x] ローカルでindex.html生成とブラウザ表示確認
- [x] フッターレイアウトとリンクの動作確認
- [x] CSSスタイルの適用確認

🤖 Generated with [Claude Code](https://claude.ai/code)