### PR TITLE
フィード間URL重複除去機能を実装 (Fixes #17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,28 +55,28 @@ https://unsolublesugar.github.io/daily-tech-news/
 - [現状のAIが全然使い物にならないのは、非常に正しくて、そして間違っている。](https://anond.hatelabo.jp/20250628122821)
 - [プログラミング1ミリも分からない人がGemini CLI始めるまでの全手順（Win篇）｜ミヤマ｜営業部にいるデザイナー](https://note.com/mmmiyama/n/n9fa6839beb06)
 - [ターミナルを使う人は、とりあえず「mise」を入れておく時代。　　・・・を夢見て。](https://zenn.dev/dress_code/articles/a99ff13634bbe6)
-- [「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ](https://www.m3tech.blog/entry/2025/06/29/110000)
 - [Claude Codeを実際のプロジェクトにうまく適用させていくTips10選 - Qiita](https://qiita.com/nokonoko_1203/items/67f8692a0a3ca7e621f3)
+- [孫正義「4.8兆円で超知能（ASI）の胴元になる」株主総会書き起こし - エンジニアtype | 転職type](https://type.jp/et/feature/28743/)
 
 
 ---
 ## <img src="https://b.hatena.ne.jp/favicon.ico" width="16" height="16" alt="はてなブックマーク - IT（新着）"> はてなブックマーク - IT（新着）
 
-- [「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ](https://www.m3tech.blog/entry/2025/06/29/110000)
 - [結局お前らはITエンジニアでなく、ITカルトではなかろうか？](https://anond.hatelabo.jp/20250628113111)
 - [Route 53 プライベートホストゾーンへオンプレミスの DNS サーバーからサブドメインを委任できるようになったので試してみた - Qiita](https://qiita.com/takeda_h/items/b56718ee53fcbbf5740b)
 - [最大の差別化要因はWebAssemblyの採用 ―― Fastly共同創業者Tyler McMullen氏に聞く次世代CDNの最前線 | gihyo.jp](https://gihyo.jp/article/2025/06/fastly-tyler-mcmullen)
-- [プログラミング1ミリも分からない人がGemini CLI始めるまでの全手順（Win篇）｜ミヤマ｜営業部にいるデザイナー](https://note.com/mmmiyama/n/n9fa6839beb06)
+- [Markdownで書いた社内ドキュメント、どう共有してる？ AWSで構築するセキュアな自動公開パイプライン](https://zenn.dev/nttdata_tech/articles/1c945dd56b374e)
+- [o3 MCPでClaude Codeが最強の検索力を手に入れた](https://share.google/5GQ578Rnl5nQgxxj0)
 
 
 ---
 ## <img src="https://dev.classmethod.jp/favicon.ico" width="16" height="16" alt="DevelopersIO"> DevelopersIO
 
+- [【ブースレポート】AWS Supply Chainのデモを見てきた #AWSSummit](https://dev.classmethod.jp/articles/shoma-booth-report-demo-aws-supply-chain-awssummit/)
 - [Dagsterとdbt CoreをECS on Fargateで構築する](https://dev.classmethod.jp/articles/dagster-dbt-core-ecs-sample/)
 - [[作ってみた] レシートプリンター付きデバイスを使ってメモを出してみた](https://dev.classmethod.jp/articles/dev-receipt-printer-device-memo-output-maruto/)
 - [[アップデート] Amazon Route 53 Resolver Endpointがプライベートホストゾーンの DNS 委任をサポートするようになりました](https://dev.classmethod.jp/articles/amazon-route-53-resolver-endpoints-dns-delegation-private-hosted-zones/)
 - [[セッションレポート] AWS で実現する患者中心の医療サービス変革 ～デジタルトランスフォーメーションによる新たな医療の未来～（AWS-31）#AWSSummit](https://dev.classmethod.jp/articles/202506-aws-summit-2025-aws-31/)
-- [【ブースレポート】カメラで読み込んだ譜面をロボットアームで即興演奏するピアノボットが面白い #AWSSummit](https://dev.classmethod.jp/articles/awssummit-2025-pianobot-booth/)
 
 
 ---

--- a/archives/2025/06/2025-06-29.md
+++ b/archives/2025/06/2025-06-29.md
@@ -55,28 +55,28 @@ https://unsolublesugar.github.io/daily-tech-news/
 - [現状のAIが全然使い物にならないのは、非常に正しくて、そして間違っている。](https://anond.hatelabo.jp/20250628122821)
 - [プログラミング1ミリも分からない人がGemini CLI始めるまでの全手順（Win篇）｜ミヤマ｜営業部にいるデザイナー](https://note.com/mmmiyama/n/n9fa6839beb06)
 - [ターミナルを使う人は、とりあえず「mise」を入れておく時代。　　・・・を夢見て。](https://zenn.dev/dress_code/articles/a99ff13634bbe6)
-- [「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ](https://www.m3tech.blog/entry/2025/06/29/110000)
 - [Claude Codeを実際のプロジェクトにうまく適用させていくTips10選 - Qiita](https://qiita.com/nokonoko_1203/items/67f8692a0a3ca7e621f3)
+- [孫正義「4.8兆円で超知能（ASI）の胴元になる」株主総会書き起こし - エンジニアtype | 転職type](https://type.jp/et/feature/28743/)
 
 
 ---
 ## <img src="https://b.hatena.ne.jp/favicon.ico" width="16" height="16" alt="はてなブックマーク - IT（新着）"> はてなブックマーク - IT（新着）
 
-- [「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ](https://www.m3tech.blog/entry/2025/06/29/110000)
 - [結局お前らはITエンジニアでなく、ITカルトではなかろうか？](https://anond.hatelabo.jp/20250628113111)
 - [Route 53 プライベートホストゾーンへオンプレミスの DNS サーバーからサブドメインを委任できるようになったので試してみた - Qiita](https://qiita.com/takeda_h/items/b56718ee53fcbbf5740b)
 - [最大の差別化要因はWebAssemblyの採用 ―― Fastly共同創業者Tyler McMullen氏に聞く次世代CDNの最前線 | gihyo.jp](https://gihyo.jp/article/2025/06/fastly-tyler-mcmullen)
-- [プログラミング1ミリも分からない人がGemini CLI始めるまでの全手順（Win篇）｜ミヤマ｜営業部にいるデザイナー](https://note.com/mmmiyama/n/n9fa6839beb06)
+- [Markdownで書いた社内ドキュメント、どう共有してる？ AWSで構築するセキュアな自動公開パイプライン](https://zenn.dev/nttdata_tech/articles/1c945dd56b374e)
+- [o3 MCPでClaude Codeが最強の検索力を手に入れた](https://share.google/5GQ578Rnl5nQgxxj0)
 
 
 ---
 ## <img src="https://dev.classmethod.jp/favicon.ico" width="16" height="16" alt="DevelopersIO"> DevelopersIO
 
+- [【ブースレポート】AWS Supply Chainのデモを見てきた #AWSSummit](https://dev.classmethod.jp/articles/shoma-booth-report-demo-aws-supply-chain-awssummit/)
 - [Dagsterとdbt CoreをECS on Fargateで構築する](https://dev.classmethod.jp/articles/dagster-dbt-core-ecs-sample/)
 - [[作ってみた] レシートプリンター付きデバイスを使ってメモを出してみた](https://dev.classmethod.jp/articles/dev-receipt-printer-device-memo-output-maruto/)
 - [[アップデート] Amazon Route 53 Resolver Endpointがプライベートホストゾーンの DNS 委任をサポートするようになりました](https://dev.classmethod.jp/articles/amazon-route-53-resolver-endpoints-dns-delegation-private-hosted-zones/)
 - [[セッションレポート] AWS で実現する患者中心の医療サービス変革 ～デジタルトランスフォーメーションによる新たな医療の未来～（AWS-31）#AWSSummit](https://dev.classmethod.jp/articles/202506-aws-summit-2025-aws-31/)
-- [【ブースレポート】カメラで読み込んだ譜面をロボットアームで即興演奏するピアノボットが面白い #AWSSummit](https://dev.classmethod.jp/articles/awssummit-2025-pianobot-booth/)
 
 
 ---

--- a/index.html
+++ b/index.html
@@ -265,15 +265,6 @@
             </div>
         </div>
     </a>
-    <a href="https://www.m3tech.blog/entry/2025/06/29/110000" class="card">
-        <div class="card-content">
-            <img src="https://cdn.image.st-hatena.com/image/scale/ac19f8b37b13e1f29fe12c92d6ae177534e24840/backend=imagemagick;version=1;width=1300/https%3A%2F%2Fcdn-ak.f.st-hatena.com%2Fimages%2Ffotolife%2Fm%2Fm3tech%2F20250629%2F20250629110005.png" width="120" height="90" alt="「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ" class="card-image">
-            <div class="card-text">
-                <h4 class="card-title">「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ</h4>
-                <p class="card-source">はてなブックマーク - IT（人気）</p>
-            </div>
-        </div>
-    </a>
     <a href="https://qiita.com/nokonoko_1203/items/67f8692a0a3ca7e621f3" class="card">
         <div class="card-content">
             <div class="card-text">
@@ -282,17 +273,17 @@
             </div>
         </div>
     </a>
-    <hr>
-    <h2><img src="https://b.hatena.ne.jp/favicon.ico" width="16" height="16" alt="はてなブックマーク - IT（新着）"> はてなブックマーク - IT（新着）</h2>
-    <a href="https://www.m3tech.blog/entry/2025/06/29/110000" class="card">
+    <a href="https://type.jp/et/feature/28743/" class="card">
         <div class="card-content">
-            <img src="https://cdn.image.st-hatena.com/image/scale/ac19f8b37b13e1f29fe12c92d6ae177534e24840/backend=imagemagick;version=1;width=1300/https%3A%2F%2Fcdn-ak.f.st-hatena.com%2Fimages%2Ffotolife%2Fm%2Fm3tech%2F20250629%2F20250629110005.png" width="120" height="90" alt="「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ" class="card-image">
+            <img src="https://type.jp/et/feature/wp-content/uploads/2025/06/e711f96bdd6c98f06dfe281b9b95a9ae.jpg" width="120" height="90" alt="孫正義「4.8兆円で超知能（ASI）の胴元になる」株主総会書き起こし - エンジニアtype | 転職type" class="card-image">
             <div class="card-text">
-                <h4 class="card-title">「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ</h4>
-                <p class="card-source">はてなブックマーク - IT（新着）</p>
+                <h4 class="card-title">孫正義「4.8兆円で超知能（ASI）の胴元になる」株主総会書き起こし - エンジニアtype | 転職type</h4>
+                <p class="card-source">はてなブックマーク - IT（人気）</p>
             </div>
         </div>
     </a>
+    <hr>
+    <h2><img src="https://b.hatena.ne.jp/favicon.ico" width="16" height="16" alt="はてなブックマーク - IT（新着）"> はてなブックマーク - IT（新着）</h2>
     <a href="https://anond.hatelabo.jp/20250628113111" class="card">
         <div class="card-content">
             <img src="https://anond.hatelabo.jp/images/og-image-1500.gif" width="120" height="90" alt="結局お前らはITエンジニアでなく、ITカルトではなかろうか？" class="card-image">
@@ -320,17 +311,35 @@
             </div>
         </div>
     </a>
-    <a href="https://note.com/mmmiyama/n/n9fa6839beb06" class="card">
+    <a href="https://zenn.dev/nttdata_tech/articles/1c945dd56b374e" class="card">
         <div class="card-content">
-            <img src="https://assets.st-note.com/production/uploads/images/198712487/rectangle_large_type_2_5f1a4e558d486194e3c571ea41e519e1.jpeg?fit=bounds&quality=85&width=1280" width="120" height="90" alt="プログラミング1ミリも分からない人がGemini CLI始めるまでの全手順（Win篇）｜ミヤマ｜営業部にいるデザイナー" class="card-image">
+            <img src="https://res.cloudinary.com/zenn/image/upload/s--HQgCRgrZ--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:Markdown%25E3%2581%25A7%25E6%259B%25B8%25E3%2581%2584%25E3%2581%259F%25E7%25A4%25BE%25E5%2586%2585%25E3%2583%2589%25E3%2582%25AD%25E3%2583%25A5%25E3%2583%25A1%25E3%2583%25B3%25E3%2583%2588%25E3%2580%2581%25E3%2581%25A9%25E3%2581%2586%25E5%2585%25B1%25E6%259C%2589%25E3%2581%2597%25E3%2581%25A6%25E3%2582%258B%25EF%25BC%259F%2520AWS%25E3%2581%25A7%25E6%25A7%258B%25E7%25AF%2589%25E3%2581%2599%25E3%2582%258B%25E3%2582%25BB%25E3%2582%25AD%25E3%2583%25A5%25E3%2582%25A2%25E3%2581%25AA%25E8%2587%25AA%25E5%258B%2595%25E5%2585%25AC%25E9%2596%258B%25E3%2583%2591%25E3%2582%25A4%25E3%2583%2597%25E3%2583%25A9%25E3%2582%25A4%25E3%2583%25B3%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_34:Yasuaki%2520Okumura%2Cx_220%2Cy_108/bo_3px_solid_rgb:d6e3ed%2Cg_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzg2ZTQyNDMyMWQuanBlZw==%2Cr_20%2Cw_90%2Cx_92%2Cy_102/g_south_west%2Ch_34%2Cl_default:og-publication-pro-mark-xcosax%2Cw_34%2Cx_217%2Cy_158/co_rgb:6e7b85%2Cg_south_west%2Cl_text:notosansjp-medium.otf_30:NTT%2520DATA%2520TECH%2Cx_255%2Cy_160/bo_4px_solid_white%2Cg_south_west%2Ch_50%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyL2ZmMDU2NTY3YjguanBlZw==%2Cr_max%2Cw_50%2Cx_139%2Cy_84/v1627283836/default/og-base-w1200-v2.png" width="120" height="90" alt="Markdownで書いた社内ドキュメント、どう共有してる？ AWSで構築するセキュアな自動公開パイプライン" class="card-image">
             <div class="card-text">
-                <h4 class="card-title">プログラミング1ミリも分からない人がGemini CLI始めるまでの全手順（Win篇）｜ミヤマ｜営業部にいるデザイナー</h4>
+                <h4 class="card-title">Markdownで書いた社内ドキュメント、どう共有してる？ AWSで構築するセキュアな自動公開パイプライン</h4>
+                <p class="card-source">はてなブックマーク - IT（新着）</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://share.google/5GQ578Rnl5nQgxxj0" class="card">
+        <div class="card-content">
+            <img src="https://res.cloudinary.com/zenn/image/upload/s--xAYvgHwM--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:o3%2520MCP%25E3%2581%25A7Claude%2520Code%25E3%2581%258C%25E6%259C%2580%25E5%25BC%25B7%25E3%2581%25AE%25E6%25A4%259C%25E7%25B4%25A2%25E5%258A%259B%25E3%2582%2592%25E6%2589%258B%25E3%2581%25AB%25E5%2585%25A5%25E3%2582%258C%25E3%2581%259F%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_37:%25E3%2582%2588%25E3%2581%2597%25E3%2581%2593%2Cx_203%2Cy_121/g_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9saDMuZ29vZ2xldXNlcmNvbnRlbnQuY29tL2EtL0FPaDE0R2kwU3JDUjBpVERyUHpqWnF4YjJLZ0tueHgtamE0N253SEE0NGE4RDhrPXMyNTAtYw==%2Cr_max%2Cw_90%2Cx_87%2Cy_95/v1627283836/default/og-base-w1200-v2.png" width="120" height="90" alt="o3 MCPでClaude Codeが最強の検索力を手に入れた" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">o3 MCPでClaude Codeが最強の検索力を手に入れた</h4>
                 <p class="card-source">はてなブックマーク - IT（新着）</p>
             </div>
         </div>
     </a>
     <hr>
     <h2><img src="https://dev.classmethod.jp/favicon.ico" width="16" height="16" alt="DevelopersIO"> DevelopersIO</h2>
+    <a href="https://dev.classmethod.jp/articles/shoma-booth-report-demo-aws-supply-chain-awssummit/" class="card">
+        <div class="card-content">
+            <img src="https://images.ctfassets.net/ct0aopd36mqt/6mDy5OHyuWO0BYkCTdEVsb/fb81a40db3365780c00e8d5c8927d5c0/eyecatch_awssummitjapan2025_nomal_1200x630.jpg" width="120" height="90" alt="【ブースレポート】AWS Supply Chainのデモを見てきた #AWSSummit" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">【ブースレポート】AWS Supply Chainのデモを見てきた #AWSSummit</h4>
+                <p class="card-source">DevelopersIO</p>
+            </div>
+        </div>
+    </a>
     <a href="https://dev.classmethod.jp/articles/dagster-dbt-core-ecs-sample/" class="card">
         <div class="card-content">
             <img src="https://devio2024-media.developers.io/image/upload/v1751177666/user-gen-eyecatch/hmskqgbszs1ltpgomkkn.png" width="120" height="90" alt="Dagsterとdbt CoreをECS on Fargateで構築する" class="card-image">
@@ -363,15 +372,6 @@
             <img src="https://images.ctfassets.net/ct0aopd36mqt/IpyxwdJt9befE2LRbgxQg/028ee4834e885c77086d6c53a87f1c10/eyecatch_awssummitjapan2025_sessionj_1200x630.jpg" width="120" height="90" alt="[セッションレポート] AWS で実現する患者中心の医療サービス変革 ～デジタルトランスフォーメーションによる新たな医療の未来～（AWS-31）#AWSSummit" class="card-image">
             <div class="card-text">
                 <h4 class="card-title">[セッションレポート] AWS で実現する患者中心の医療サービス変革 ～デジタルトランスフォーメーションによる新たな医療の未来～（AWS-31）#AWSSummit</h4>
-                <p class="card-source">DevelopersIO</p>
-            </div>
-        </div>
-    </a>
-    <a href="https://dev.classmethod.jp/articles/awssummit-2025-pianobot-booth/" class="card">
-        <div class="card-content">
-            <img src="https://devio2024-media.developers.io/image/upload/v1751170204/user-gen-eyecatch/sdv2cmaj4ss7ucafcsfj.jpg" width="120" height="90" alt="【ブースレポート】カメラで読み込んだ譜面をロボットアームで即興演奏するピアノボットが面白い #AWSSummit" class="card-image">
-            <div class="card-text">
-                <h4 class="card-title">【ブースレポート】カメラで読み込んだ譜面をロボットアームで即興演奏するピアノボットが面白い #AWSSummit</h4>
                 <p class="card-source">DevelopersIO</p>
             </div>
         </div>
@@ -530,7 +530,7 @@
     </a>
     <a href="https://www.infoq.com/jp/news/2025/06/cisco-jarvis-ai-assistant/?utm_campaign=infoq_content&utm_source=infoq&utm_medium=feed&utm_term=global" class="card">
         <div class="card-content">
-            <img src="https://cdn.infoq.com/statics_s2_20250605075544/styles/static/images/logo/logo-big.jpg" width="120" height="90" alt="CiscoがJARVISを発表：プラットフォームエンジニアリングチームのためのAIアシスタント" class="card-image">
+            <img src="https://cdn.infoq.com/statics_s1_20250605075448/styles/static/images/logo/logo-big.jpg" width="120" height="90" alt="CiscoがJARVISを発表：プラットフォームエンジニアリングチームのためのAIアシスタント" class="card-image">
             <div class="card-text">
                 <h4 class="card-title">CiscoがJARVISを発表：プラットフォームエンジニアリングチームのためのAIアシスタント</h4>
                 <p class="card-source">InfoQ Japan</p>

--- a/rss.xml
+++ b/rss.xml
@@ -135,13 +135,6 @@
       <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
     </item>
     <item>
-      <title>&lt;img src=&quot;https://b.hatena.ne.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;はてなブックマーク - IT（人気）&quot;&gt; 「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ</title>
-      <link>https://www.m3tech.blog/entry/2025/06/29/110000</link>
-      <description>はてなブックマーク - IT（人気）からの記事: 「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ</description>
-      <guid>https://www.m3tech.blog/entry/2025/06/29/110000</guid>
-      <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
-    </item>
-    <item>
       <title>&lt;img src=&quot;https://b.hatena.ne.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;はてなブックマーク - IT（人気）&quot;&gt; Claude Codeを実際のプロジェクトにうまく適用させていくTips10選 - Qiita</title>
       <link>https://qiita.com/nokonoko_1203/items/67f8692a0a3ca7e621f3</link>
       <description>はてなブックマーク - IT（人気）からの記事: Claude Codeを実際のプロジェクトにうまく適用させていくTips10選 - Qiita</description>
@@ -149,10 +142,10 @@
       <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
     </item>
     <item>
-      <title>&lt;img src=&quot;https://b.hatena.ne.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;はてなブックマーク - IT（新着）&quot;&gt; 「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ</title>
-      <link>https://www.m3tech.blog/entry/2025/06/29/110000</link>
-      <description>はてなブックマーク - IT（新着）からの記事: 「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ</description>
-      <guid>https://www.m3tech.blog/entry/2025/06/29/110000</guid>
+      <title>&lt;img src=&quot;https://b.hatena.ne.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;はてなブックマーク - IT（人気）&quot;&gt; 孫正義「4.8兆円で超知能（ASI）の胴元になる」株主総会書き起こし - エンジニアtype | 転職type</title>
+      <link>https://type.jp/et/feature/28743/</link>
+      <description>はてなブックマーク - IT（人気）からの記事: 孫正義「4.8兆円で超知能（ASI）の胴元になる」株主総会書き起こし - エンジニアtype | 転職type</description>
+      <guid>https://type.jp/et/feature/28743/</guid>
       <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
     </item>
     <item>
@@ -177,11 +170,25 @@
       <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
     </item>
     <item>
-      <title>&lt;img src=&quot;https://b.hatena.ne.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;はてなブックマーク - IT（新着）&quot;&gt; プログラミング1ミリも分からない人がGemini CLI始めるまでの全手順（Win篇）｜ミヤマ｜営業部にいるデザイナー</title>
-      <link>https://note.com/mmmiyama/n/n9fa6839beb06</link>
-      <description>はてなブックマーク - IT（新着）からの記事: プログラミング1ミリも分からない人がGemini CLI始めるまでの全手順（Win篇）｜ミヤマ｜営業部にいるデザイナー</description>
-      <guid>https://note.com/mmmiyama/n/n9fa6839beb06</guid>
+      <title>&lt;img src=&quot;https://b.hatena.ne.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;はてなブックマーク - IT（新着）&quot;&gt; Markdownで書いた社内ドキュメント、どう共有してる？ AWSで構築するセキュアな自動公開パイプライン</title>
+      <link>https://zenn.dev/nttdata_tech/articles/1c945dd56b374e</link>
+      <description>はてなブックマーク - IT（新着）からの記事: Markdownで書いた社内ドキュメント、どう共有してる？ AWSで構築するセキュアな自動公開パイプライン</description>
+      <guid>https://zenn.dev/nttdata_tech/articles/1c945dd56b374e</guid>
       <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
+    </item>
+    <item>
+      <title>&lt;img src=&quot;https://b.hatena.ne.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;はてなブックマーク - IT（新着）&quot;&gt; o3 MCPでClaude Codeが最強の検索力を手に入れた</title>
+      <link>https://share.google/5GQ578Rnl5nQgxxj0</link>
+      <description>はてなブックマーク - IT（新着）からの記事: o3 MCPでClaude Codeが最強の検索力を手に入れた</description>
+      <guid>https://share.google/5GQ578Rnl5nQgxxj0</guid>
+      <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
+    </item>
+    <item>
+      <title>&lt;img src=&quot;https://dev.classmethod.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;DevelopersIO&quot;&gt; 【ブースレポート】AWS Supply Chainのデモを見てきた #AWSSummit</title>
+      <link>https://dev.classmethod.jp/articles/shoma-booth-report-demo-aws-supply-chain-awssummit/</link>
+      <description>DevelopersIOからの記事: 【ブースレポート】AWS Supply Chainのデモを見てきた #AWSSummit</description>
+      <guid>https://dev.classmethod.jp/articles/shoma-booth-report-demo-aws-supply-chain-awssummit/</guid>
+      <pubDate>Sun, 29 Jun 2025 06:36:16 +0000</pubDate>
     </item>
     <item>
       <title>&lt;img src=&quot;https://dev.classmethod.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;DevelopersIO&quot;&gt; Dagsterとdbt CoreをECS on Fargateで構築する</title>
@@ -210,13 +217,6 @@
       <description>DevelopersIOからの記事: [セッションレポート] AWS で実現する患者中心の医療サービス変革 ～デジタルトランスフォーメーションによる新たな医療の未来～（AWS-31）#AWSSummit</description>
       <guid>https://dev.classmethod.jp/articles/202506-aws-summit-2025-aws-31/</guid>
       <pubDate>Sun, 29 Jun 2025 05:39:16 +0000</pubDate>
-    </item>
-    <item>
-      <title>&lt;img src=&quot;https://dev.classmethod.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;DevelopersIO&quot;&gt; 【ブースレポート】カメラで読み込んだ譜面をロボットアームで即興演奏するピアノボットが面白い #AWSSummit</title>
-      <link>https://dev.classmethod.jp/articles/awssummit-2025-pianobot-booth/</link>
-      <description>DevelopersIOからの記事: 【ブースレポート】カメラで読み込んだ譜面をロボットアームで即興演奏するピアノボットが面白い #AWSSummit</description>
-      <guid>https://dev.classmethod.jp/articles/awssummit-2025-pianobot-booth/</guid>
-      <pubDate>Sun, 29 Jun 2025 04:25:23 +0000</pubDate>
     </item>
     <item>
       <title>&lt;img src=&quot;https://gihyo.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;gihyo.jp&quot;&gt; Anthropic、ワンクリックでローカルMCPサーバーをインストールできる「Desktop Extensions」をリリース</title>


### PR DESCRIPTION
## Summary
- フィード間でのURL重複を検出・除去する機能を実装
- 重複除去後の記事数を目標件数まで自動補填
- 既存のイベント重複除去機能との統合

## Test plan
- [x] URL重複除去機能の動作確認
- [x] 記事数の目標件数維持確認  
- [x] イベント重複除去機能との統合確認
- [x] 全出力ファイル（HTML、Markdown、RSS）の生成確認

🤖 Generated with [Claude Code](https://claude.ai/code)