### PR TITLE
🐛 fix: .gitignoreから自動生成ファイルを削除 (#27)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,8 +66,3 @@ venv.bak/
 ehthumbs.db
 Thumbs.db
 
-# Auto-generated files
-README.md
-index.html
-rss.xml
-archives/


### PR DESCRIPTION
Fixes #27\n\n## 変更内容\n-  から、、、、 といった自動生成ファイルの記述を削除しました。\n\n## 変更理由\n- GitHub Actionsでこれらのファイルが正しくコミット・プッシュされるようにするため。\n- 以前のコミットで誤ってに追加してしまったため、その修正です。\n\n## テスト方法\n-  の内容を確認し、該当する行が削除されていることを確認しました。\n\n## 関連Issue\n- Fixes #27