### PR TITLE
🔧 フィルタリング: はてなブックマークからはてな匿名ダイアリーの記事を除外 (#35)

### DIFF
--- a/fetch_news.py
+++ b/fetch_news.py
@@ -179,6 +179,23 @@ class ThumbnailCache:
         if keys_to_remove:
             print(f"Cleaned up {len(keys_to_remove)} old cache entries")
 
+def filter_hatena_anonymous_entries(entries):
+    """はてな匿名ダイアリーの記事を除外する"""
+    filtered_entries = []
+    excluded_count = 0
+    
+    for entry in entries:
+        # リンクURLがはてな匿名ダイアリーかチェック
+        if hasattr(entry, 'link') and 'anond.hatelabo.jp' in entry.link:
+            excluded_count += 1
+            continue
+        filtered_entries.append(entry)
+    
+    if excluded_count > 0:
+        print(f"Excluded {excluded_count} hatena anonymous diary entries")
+    
+    return filtered_entries
+
 def fetch_feed_entries(feed_url):
     """指定されたURLからRSSフィードのエントリーを取得する"""
     try:
@@ -798,6 +815,11 @@ if __name__ == "__main__":
     for name, feed_info in FEEDS.items():
         print(f"Fetching entries from {name}...")
         entries = fetch_feed_entries(feed_info["url"])
+        
+        # はてなブックマークのフィードに対してはてな匿名ダイアリーを除外
+        if name in ["はてなブックマーク - IT（人気）", "はてなブックマーク - IT（新着）"]:
+            entries = filter_hatena_anonymous_entries(entries)
+        
         all_entries[name] = entries
     
     # フィード間URL重複除去と補填


### PR DESCRIPTION
Closes #35

## 変更内容
- `filter_hatena_anonymous_entries()` 関数を新規追加
- はてなブックマーク - IT（人気）とはてなブックマーク - IT（新着）に対してフィルタリングを適用
- `anond.hatelabo.jp` ドメインの記事を自動除外
- 除外された記事の分は他の記事で自動補填

## 変更理由
- 匿名投稿の記事は技術系ニュースとしての信頼性が低い
- より質の高い技術情報にフォーカスしたい

## テスト方法
- `python3 fetch_news.py` を実行
- はてなブックマーク - IT（人気）: 4件除外確認
- はてなブックマーク - IT（新着）: 4件除外確認
- README.md、index.html、rss.xml からはてな匿名ダイアリー記事が除外されていることを確認

## 関連Issue
- Closes #35