### PR TITLE
Slack通知機能の実装

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -58,9 +58,15 @@ jobs:
       id: slack-message
       run: |
         if [ -f slack_message.json ]; then
-          echo "content=$(cat slack_message.json | jq -c .)" >> $GITHUB_OUTPUT
+          # JSONファイルを環境変数経由で安全に読み取り
+          SLACK_CONTENT=$(cat slack_message.json | tr -d '\n')
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$SLACK_CONTENT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
         else
-          echo "content={\"text\":\"📰 今日のテックニュース更新完了！\",\"blocks\":[{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"最新のテックニュースを更新しました！\\n\\n🔗 <https://unsolublesugar.github.io/daily-tech-news/|カード表示版を見る>\\n📰 <https://github.com/unsolublesugar/daily-tech-news|GitHub リポジトリ>\"}}]}" >> $GITHUB_OUTPUT
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo '{"text":"📰 今日のテックニュース更新完了！","blocks":[{"type":"section","text":{"type":"mrkdwn","text":"最新のテックニュースを更新しました！\n\n🔗 <https://unsolublesugar.github.io/daily-tech-news/|カード表示版を見る>\n📰 <https://github.com/unsolublesugar/daily-tech-news|GitHub リポジトリ>"}}]}' >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
         fi
         
     - name: Notify Slack
@@ -68,6 +74,6 @@ jobs:
       if: success()
       with:
         status: custom
-        custom_payload: ${{ fromJson(steps.slack-message.outputs.content) }}
+        custom_payload: ${{ steps.slack-message.outputs.content }}
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -53,3 +53,47 @@ jobs:
           git commit -m "🗞️ 毎日のテックニュース更新 $(date '+%Y-%m-%d')"
           git push
         fi
+        
+    - name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      if: success()
+      with:
+        status: custom
+        custom_payload: |
+          {
+            "text": "📰 今日のテックニュース更新完了！",
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "📰 今日のテックニュース更新完了"
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "最新のテックニュースを更新しました！\n\n🔗 <https://unsolublesugar.github.io/daily-tech-news/|カード表示版を見る>\n📰 <https://github.com/unsolublesugar/daily-tech-news|GitHub リポジトリ>"
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*📊 更新サマリー*\n• Tech Blog Weekly から5件\n• Zenn から5件\n• Qiita から5件\n• はてなブックマーク から10件\n• その他の技術メディアから多数"
+                }
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "⚡ GitHub Actions で自動更新 | 🚀 キャッシュ機能で高速化"
+                  }
+                ]
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -54,46 +54,20 @@ jobs:
           git push
         fi
         
+    - name: Read Slack message
+      id: slack-message
+      run: |
+        if [ -f slack_message.json ]; then
+          echo "content=$(cat slack_message.json | jq -c .)" >> $GITHUB_OUTPUT
+        else
+          echo "content={\"text\":\"📰 今日のテックニュース更新完了！\",\"blocks\":[{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"最新のテックニュースを更新しました！\\n\\n🔗 <https://unsolublesugar.github.io/daily-tech-news/|カード表示版を見る>\\n📰 <https://github.com/unsolublesugar/daily-tech-news|GitHub リポジトリ>\"}}]}" >> $GITHUB_OUTPUT
+        fi
+        
     - name: Notify Slack
       uses: 8398a7/action-slack@v3
       if: success()
       with:
         status: custom
-        custom_payload: |
-          {
-            "text": "📰 今日のテックニュース更新完了！",
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": "📰 今日のテックニュース更新完了"
-                }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "最新のテックニュースを更新しました！\n\n🔗 <https://unsolublesugar.github.io/daily-tech-news/|カード表示版を見る>\n📰 <https://github.com/unsolublesugar/daily-tech-news|GitHub リポジトリ>"
-                }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "*📊 更新サマリー*\n• Tech Blog Weekly から5件\n• Zenn から5件\n• Qiita から5件\n• はてなブックマーク から10件\n• その他の技術メディアから多数"
-                }
-              },
-              {
-                "type": "context",
-                "elements": [
-                  {
-                    "type": "mrkdwn",
-                    "text": "⚡ GitHub Actions で自動更新 | 🚀 キャッシュ機能で高速化"
-                  }
-                ]
-              }
-            ]
-          }
+        custom_payload: ${{ fromJson(steps.slack-message.outputs.content) }}
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ https://unsolublesugar.github.io/daily-tech-news/
 - [【Web Bluetooth API】Joy-Con 2 をプレゼンリモコンにする](https://zenn.dev/mascii/articles/joy-con-2-web-bluetooth-api)
 - [Gemini CLIをソース解析して発見したコーギーの出現方法](https://zenn.dev/oikon/articles/c8a887f00dd219)
 - [AIエージェントでバグバウンティ！ Cline × Claude Code × GPT-o3 で $2,000 を獲得した話](https://zenn.dev/grandchildrice/articles/499e22b0e9e4c8)
-- [Claude Codeにコマンド一発でMCPサーバを簡単設定](https://zenn.dev/karaage0703/articles/3bd2957807f311)
+- [初めてのTTSモデルをずんだもんのデータで作ってみた with LLaSA](https://zenn.dev/aratako_lm/articles/7e0b0b6e51baa6)
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ https://unsolublesugar.github.io/daily-tech-news/
 - [【Web Bluetooth API】Joy-Con 2 をプレゼンリモコンにする](https://zenn.dev/mascii/articles/joy-con-2-web-bluetooth-api)
 - [Gemini CLIをソース解析して発見したコーギーの出現方法](https://zenn.dev/oikon/articles/c8a887f00dd219)
 - [AIエージェントでバグバウンティ！ Cline × Claude Code × GPT-o3 で $2,000 を獲得した話](https://zenn.dev/grandchildrice/articles/499e22b0e9e4c8)
-- [初めてのTTSモデルをずんだもんのデータで作ってみた with LLaSA](https://zenn.dev/aratako_lm/articles/7e0b0b6e51baa6)
+- [Claude Codeにコマンド一発でMCPサーバを簡単設定](https://zenn.dev/karaage0703/articles/3bd2957807f311)
 
 
 ---
@@ -54,11 +54,11 @@ https://unsolublesugar.github.io/daily-tech-news/
 ---
 ## <img src="https://b.hatena.ne.jp/favicon.ico" width="16" height="16" alt="はてなブックマーク - IT（新着）"> はてなブックマーク - IT（新着）
 
+- [Drag-and-Drop LLMs: Zero-Shot Prompt-to-Weights](https://arxiv.org/abs/2506.16406)
 - [GitHub - kign/c4wa: A simplified subset of C transpiled into Web Assembly](https://github.com/kign/c4wa)
 - [Route 53 プライベートホストゾーンへオンプレミスの DNS サーバーからサブドメインを委任できるようになったので試してみた - Qiita](https://qiita.com/takeda_h/items/b56718ee53fcbbf5740b)
 - [最大の差別化要因はWebAssemblyの採用 ―― Fastly共同創業者Tyler McMullen氏に聞く次世代CDNの最前線 | gihyo.jp](https://gihyo.jp/article/2025/06/fastly-tyler-mcmullen)
 - [プレゼン動画自動生成ツール Mulmocast を使う](https://zenn.dev/open_developers/articles/87928c78f98210)
-- [o3 MCPでClaude Codeが最強の検索力を手に入れた](https://share.google/5GQ578Rnl5nQgxxj0)
 
 
 ---
@@ -111,6 +111,7 @@ https://unsolublesugar.github.io/daily-tech-news/
 ---
 ## <img src="https://connpass.com/favicon.ico" width="16" height="16" alt="connpass - イベント"> connpass - イベント
 
+- [【限定5名増枠】英語LT会【テーマ：開発生産性】Japanglish Tech Talk#6](https://japanglish.connpass.com/event/360913/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [Djangoもくもく会: 7回目](https://pythonista-books.connpass.com/event/360904/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [第52回CITPコミュニティ定例会](https://connpass.com/event/360908/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [誰でも参加OK！_朝活_もくもく会](https://routine-link.connpass.com/event/360902/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
@@ -120,7 +121,6 @@ https://unsolublesugar.github.io/daily-tech-news/
 - [第110回CoderDojo 浜松（2025年7月）](https://coderdojo-hamamatsu.connpass.com/event/359293/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [北千住もくもく作業・勉強部屋](https://kitasenju-verystrong.connpass.com/event/360890/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [YUMEMI × やさしい Swift 勉強会 #547 #yumemi_grow](https://yasashii-swift.connpass.com/event/360729/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
-- [朝活もくもく会 #23](https://zitox.connpass.com/event/360889/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 
 
 ---

--- a/archives/2025/06/2025-06-29.md
+++ b/archives/2025/06/2025-06-29.md
@@ -28,7 +28,7 @@ https://unsolublesugar.github.io/daily-tech-news/
 - [【Web Bluetooth API】Joy-Con 2 をプレゼンリモコンにする](https://zenn.dev/mascii/articles/joy-con-2-web-bluetooth-api)
 - [Gemini CLIをソース解析して発見したコーギーの出現方法](https://zenn.dev/oikon/articles/c8a887f00dd219)
 - [AIエージェントでバグバウンティ！ Cline × Claude Code × GPT-o3 で $2,000 を獲得した話](https://zenn.dev/grandchildrice/articles/499e22b0e9e4c8)
-- [Claude Codeにコマンド一発でMCPサーバを簡単設定](https://zenn.dev/karaage0703/articles/3bd2957807f311)
+- [初めてのTTSモデルをずんだもんのデータで作ってみた with LLaSA](https://zenn.dev/aratako_lm/articles/7e0b0b6e51baa6)
 
 
 ---

--- a/archives/2025/06/2025-06-29.md
+++ b/archives/2025/06/2025-06-29.md
@@ -28,7 +28,7 @@ https://unsolublesugar.github.io/daily-tech-news/
 - [【Web Bluetooth API】Joy-Con 2 をプレゼンリモコンにする](https://zenn.dev/mascii/articles/joy-con-2-web-bluetooth-api)
 - [Gemini CLIをソース解析して発見したコーギーの出現方法](https://zenn.dev/oikon/articles/c8a887f00dd219)
 - [AIエージェントでバグバウンティ！ Cline × Claude Code × GPT-o3 で $2,000 を獲得した話](https://zenn.dev/grandchildrice/articles/499e22b0e9e4c8)
-- [初めてのTTSモデルをずんだもんのデータで作ってみた with LLaSA](https://zenn.dev/aratako_lm/articles/7e0b0b6e51baa6)
+- [Claude Codeにコマンド一発でMCPサーバを簡単設定](https://zenn.dev/karaage0703/articles/3bd2957807f311)
 
 
 ---
@@ -54,11 +54,11 @@ https://unsolublesugar.github.io/daily-tech-news/
 ---
 ## <img src="https://b.hatena.ne.jp/favicon.ico" width="16" height="16" alt="はてなブックマーク - IT（新着）"> はてなブックマーク - IT（新着）
 
+- [Drag-and-Drop LLMs: Zero-Shot Prompt-to-Weights](https://arxiv.org/abs/2506.16406)
 - [GitHub - kign/c4wa: A simplified subset of C transpiled into Web Assembly](https://github.com/kign/c4wa)
 - [Route 53 プライベートホストゾーンへオンプレミスの DNS サーバーからサブドメインを委任できるようになったので試してみた - Qiita](https://qiita.com/takeda_h/items/b56718ee53fcbbf5740b)
 - [最大の差別化要因はWebAssemblyの採用 ―― Fastly共同創業者Tyler McMullen氏に聞く次世代CDNの最前線 | gihyo.jp](https://gihyo.jp/article/2025/06/fastly-tyler-mcmullen)
 - [プレゼン動画自動生成ツール Mulmocast を使う](https://zenn.dev/open_developers/articles/87928c78f98210)
-- [o3 MCPでClaude Codeが最強の検索力を手に入れた](https://share.google/5GQ578Rnl5nQgxxj0)
 
 
 ---
@@ -111,6 +111,7 @@ https://unsolublesugar.github.io/daily-tech-news/
 ---
 ## <img src="https://connpass.com/favicon.ico" width="16" height="16" alt="connpass - イベント"> connpass - イベント
 
+- [【限定5名増枠】英語LT会【テーマ：開発生産性】Japanglish Tech Talk#6](https://japanglish.connpass.com/event/360913/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [Djangoもくもく会: 7回目](https://pythonista-books.connpass.com/event/360904/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [第52回CITPコミュニティ定例会](https://connpass.com/event/360908/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [誰でも参加OK！_朝活_もくもく会](https://routine-link.connpass.com/event/360902/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
@@ -120,7 +121,6 @@ https://unsolublesugar.github.io/daily-tech-news/
 - [第110回CoderDojo 浜松（2025年7月）](https://coderdojo-hamamatsu.connpass.com/event/359293/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [北千住もくもく作業・勉強部屋](https://kitasenju-verystrong.connpass.com/event/360890/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [YUMEMI × やさしい Swift 勉強会 #547 #yumemi_grow](https://yasashii-swift.connpass.com/event/360729/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
-- [朝活もくもく会 #23](https://zitox.connpass.com/event/360889/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 
 
 ---

--- a/index.html
+++ b/index.html
@@ -195,11 +195,11 @@
             </div>
         </div>
     </a>
-    <a href="https://zenn.dev/aratako_lm/articles/7e0b0b6e51baa6" class="card">
+    <a href="https://zenn.dev/karaage0703/articles/3bd2957807f311" class="card">
         <div class="card-content">
-            <img src="https://res.cloudinary.com/zenn/image/upload/s--y-bx69F2--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:%25E5%2588%259D%25E3%2582%2581%25E3%2581%25A6%25E3%2581%25AETTS%25E3%2583%25A2%25E3%2583%2587%25E3%2583%25AB%25E3%2582%2592%25E3%2581%259A%25E3%2582%2593%25E3%2581%25A0%25E3%2582%2582%25E3%2582%2593%25E3%2581%25AE%25E3%2583%2587%25E3%2583%25BC%25E3%2582%25BF%25E3%2581%25A7%25E4%25BD%259C%25E3%2581%25A3%25E3%2581%25A6%25E3%2581%25BF%25E3%2581%259F%2520with%2520LLaSA%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_37:Aratako%2Cx_203%2Cy_121/g_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzY1MThmOTRmNmEuanBlZw==%2Cr_max%2Cw_90%2Cx_87%2Cy_95/v1627283836/default/og-base-w1200-v2.png" width="120" height="90" alt="初めてのTTSモデルをずんだもんのデータで作ってみた with LLaSA" class="card-image">
+            <img src="https://res.cloudinary.com/zenn/image/upload/s--qFEpkSVb--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:Claude%2520Code%25E3%2581%25AB%25E3%2582%25B3%25E3%2583%259E%25E3%2583%25B3%25E3%2583%2589%25E4%25B8%2580%25E7%2599%25BA%25E3%2581%25A7MCP%25E3%2582%25B5%25E3%2583%25BC%25E3%2583%2590%25E3%2582%2592%25E7%25B0%25A1%25E5%258D%2598%25E8%25A8%25AD%25E5%25AE%259A%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_37:%25E3%2581%258B%25E3%2582%2589%25E3%2581%2582%25E3%2581%2592%2Cx_203%2Cy_121/g_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9saDMuZ29vZ2xldXNlcmNvbnRlbnQuY29tL2EtL0FPaDE0R2hDZEtvakJfZXdDTjNCV1Z0WXIteFNIZ0hmRjlXZmt3QzI5c0Y0aXYwPXMyNTAtYw==%2Cr_max%2Cw_90%2Cx_87%2Cy_95/v1627283836/default/og-base-w1200-v2.png" width="120" height="90" alt="Claude Codeにコマンド一発でMCPサーバを簡単設定" class="card-image">
             <div class="card-text">
-                <h4 class="card-title">初めてのTTSモデルをずんだもんのデータで作ってみた with LLaSA</h4>
+                <h4 class="card-title">Claude Codeにコマンド一発でMCPサーバを簡単設定</h4>
                 <p class="card-source">Zenn</p>
             </div>
         </div>
@@ -298,6 +298,15 @@
     </a>
     <hr>
     <h2><img src="https://b.hatena.ne.jp/favicon.ico" width="16" height="16" alt="はてなブックマーク - IT（新着）"> はてなブックマーク - IT（新着）</h2>
+    <a href="https://arxiv.org/abs/2506.16406" class="card">
+        <div class="card-content">
+            <img src="https://arxiv.org/static/browse/0.3.4/images/arxiv-logo-fb.png" width="120" height="90" alt="Drag-and-Drop LLMs: Zero-Shot Prompt-to-Weights" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">Drag-and-Drop LLMs: Zero-Shot Prompt-to-Weights</h4>
+                <p class="card-source">はてなブックマーク - IT（新着）</p>
+            </div>
+        </div>
+    </a>
     <a href="https://github.com/kign/c4wa" class="card">
         <div class="card-content">
             <div class="card-text">
@@ -329,15 +338,6 @@
             <img src="https://res.cloudinary.com/zenn/image/upload/s--ttDHSOeN--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:%25E3%2583%2597%25E3%2583%25AC%25E3%2582%25BC%25E3%2583%25B3%25E5%258B%2595%25E7%2594%25BB%25E8%2587%25AA%25E5%258B%2595%25E7%2594%259F%25E6%2588%2590%25E3%2583%2584%25E3%2583%25BC%25E3%2583%25AB%2520Mulmocast%2520%25E3%2582%2592%25E4%25BD%25BF%25E3%2581%2586%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_34:%25E7%25A6%258F%25E7%2594%25B0%25E5%25BF%2597%25E9%2583%258E%2Cx_220%2Cy_108/bo_3px_solid_rgb:d6e3ed%2Cg_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzg3Nzg4MGI3YTkuanBlZw==%2Cr_20%2Cw_90%2Cx_92%2Cy_102/co_rgb:6e7b85%2Cg_south_west%2Cl_text:notosansjp-medium.otf_30:%25E3%2582%25AA%25E3%2583%25BC%25E3%2583%2597%25E3%2583%25B3%25E9%2596%258B%25E7%2599%25BA%25E3%2583%2581%25E3%2583%25BC%25E3%2583%25A0%2Cx_220%2Cy_160/bo_4px_solid_white%2Cg_south_west%2Ch_50%2Cl_fetch:aHR0cHM6Ly9saDMuZ29vZ2xldXNlcmNvbnRlbnQuY29tL2EvQUNnOG9jSk10eHRDLUlpSzFEdnk4UVVnODJaRGhCZ1gtUDZZOHVLdm1tSDhQNklVMEJzbDk4ZGI9czk2LWM=%2Cr_max%2Cw_50%2Cx_139%2Cy_84/v1627283836/default/og-base-w1200-v2.png" width="120" height="90" alt="プレゼン動画自動生成ツール Mulmocast を使う" class="card-image">
             <div class="card-text">
                 <h4 class="card-title">プレゼン動画自動生成ツール Mulmocast を使う</h4>
-                <p class="card-source">はてなブックマーク - IT（新着）</p>
-            </div>
-        </div>
-    </a>
-    <a href="https://share.google/5GQ578Rnl5nQgxxj0" class="card">
-        <div class="card-content">
-            <img src="https://res.cloudinary.com/zenn/image/upload/s--xAYvgHwM--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:o3%2520MCP%25E3%2581%25A7Claude%2520Code%25E3%2581%258C%25E6%259C%2580%25E5%25BC%25B7%25E3%2581%25AE%25E6%25A4%259C%25E7%25B4%25A2%25E5%258A%259B%25E3%2582%2592%25E6%2589%258B%25E3%2581%25AB%25E5%2585%25A5%25E3%2582%258C%25E3%2581%259F%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_37:%25E3%2582%2588%25E3%2581%2597%25E3%2581%2593%2Cx_203%2Cy_121/g_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9saDMuZ29vZ2xldXNlcmNvbnRlbnQuY29tL2EtL0FPaDE0R2kwU3JDUjBpVERyUHpqWnF4YjJLZ0tueHgtamE0N253SEE0NGE4RDhrPXMyNTAtYw==%2Cr_max%2Cw_90%2Cx_87%2Cy_95/v1627283836/default/og-base-w1200-v2.png" width="120" height="90" alt="o3 MCPでClaude Codeが最強の検索力を手に入れた" class="card-image">
-            <div class="card-text">
-                <h4 class="card-title">o3 MCPでClaude Codeが最強の検索力を手に入れた</h4>
                 <p class="card-source">はてなブックマーク - IT（新着）</p>
             </div>
         </div>
@@ -552,6 +552,15 @@
     </a>
     <hr>
     <h2><img src="https://connpass.com/favicon.ico" width="16" height="16" alt="connpass - イベント"> connpass - イベント</h2>
+    <a href="https://japanglish.connpass.com/event/360913/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom" class="card">
+        <div class="card-content">
+            <img src="https://media.connpass.com/thumbs/23/8a/238af991371fd0a0f88e2ba51426e178.png" width="120" height="90" alt="【限定5名増枠】英語LT会【テーマ：開発生産性】Japanglish Tech Talk#6" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">【限定5名増枠】英語LT会【テーマ：開発生産性】Japanglish Tech Talk#6</h4>
+                <p class="card-source">connpass - イベント</p>
+            </div>
+        </div>
+    </a>
     <a href="https://pythonista-books.connpass.com/event/360904/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom" class="card">
         <div class="card-content">
             <img src="https://media.connpass.com/thumbs/f3/a8/f3a8e339115fdd679d61de47d684e91b.png" width="120" height="90" alt="Djangoもくもく会: 7回目" class="card-image">
@@ -629,15 +638,6 @@
             <img src="https://media.connpass.com/thumbs/30/f5/30f51dd9f06aa4a6f1aeef5cc07644b5.png" width="120" height="90" alt="YUMEMI × やさしい Swift 勉強会 #547 #yumemi_grow" class="card-image">
             <div class="card-text">
                 <h4 class="card-title">YUMEMI × やさしい Swift 勉強会 #547 #yumemi_grow</h4>
-                <p class="card-source">connpass - イベント</p>
-            </div>
-        </div>
-    </a>
-    <a href="https://zitox.connpass.com/event/360889/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom" class="card">
-        <div class="card-content">
-            <img src="https://media.connpass.com/thumbs/1b/7e/1b7e6b519302c036b789295c4c0ada8c.png" width="120" height="90" alt="朝活もくもく会 #23" class="card-image">
-            <div class="card-text">
-                <h4 class="card-title">朝活もくもく会 #23</h4>
                 <p class="card-source">connpass - イベント</p>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -195,11 +195,11 @@
             </div>
         </div>
     </a>
-    <a href="https://zenn.dev/karaage0703/articles/3bd2957807f311" class="card">
+    <a href="https://zenn.dev/aratako_lm/articles/7e0b0b6e51baa6" class="card">
         <div class="card-content">
-            <img src="https://res.cloudinary.com/zenn/image/upload/s--qFEpkSVb--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:Claude%2520Code%25E3%2581%25AB%25E3%2582%25B3%25E3%2583%259E%25E3%2583%25B3%25E3%2583%2589%25E4%25B8%2580%25E7%2599%25BA%25E3%2581%25A7MCP%25E3%2582%25B5%25E3%2583%25BC%25E3%2583%2590%25E3%2582%2592%25E7%25B0%25A1%25E5%258D%2598%25E8%25A8%25AD%25E5%25AE%259A%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_37:%25E3%2581%258B%25E3%2582%2589%25E3%2581%2582%25E3%2581%2592%2Cx_203%2Cy_121/g_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9saDMuZ29vZ2xldXNlcmNvbnRlbnQuY29tL2EtL0FPaDE0R2hDZEtvakJfZXdDTjNCV1Z0WXIteFNIZ0hmRjlXZmt3QzI5c0Y0aXYwPXMyNTAtYw==%2Cr_max%2Cw_90%2Cx_87%2Cy_95/v1627283836/default/og-base-w1200-v2.png" width="120" height="90" alt="Claude Codeにコマンド一発でMCPサーバを簡単設定" class="card-image">
+            <img src="https://res.cloudinary.com/zenn/image/upload/s--y-bx69F2--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:%25E5%2588%259D%25E3%2582%2581%25E3%2581%25A6%25E3%2581%25AETTS%25E3%2583%25A2%25E3%2583%2587%25E3%2583%25AB%25E3%2582%2592%25E3%2581%259A%25E3%2582%2593%25E3%2581%25A0%25E3%2582%2582%25E3%2582%2593%25E3%2581%25AE%25E3%2583%2587%25E3%2583%25BC%25E3%2582%25BF%25E3%2581%25A7%25E4%25BD%259C%25E3%2581%25A3%25E3%2581%25A6%25E3%2581%25BF%25E3%2581%259F%2520with%2520LLaSA%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_37:Aratako%2Cx_203%2Cy_121/g_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzY1MThmOTRmNmEuanBlZw==%2Cr_max%2Cw_90%2Cx_87%2Cy_95/v1627283836/default/og-base-w1200-v2.png" width="120" height="90" alt="初めてのTTSモデルをずんだもんのデータで作ってみた with LLaSA" class="card-image">
             <div class="card-text">
-                <h4 class="card-title">Claude Codeにコマンド一発でMCPサーバを簡単設定</h4>
+                <h4 class="card-title">初めてのTTSモデルをずんだもんのデータで作ってみた with LLaSA</h4>
                 <p class="card-source">Zenn</p>
             </div>
         </div>

--- a/rss.xml
+++ b/rss.xml
@@ -72,11 +72,11 @@
       <pubDate>Sat, 28 Jun 2025 03:35:39 +0000</pubDate>
     </item>
     <item>
-      <title>&lt;img src=&quot;https://zenn.dev/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;Zenn&quot;&gt; Claude Codeにコマンド一発でMCPサーバを簡単設定</title>
-      <link>https://zenn.dev/karaage0703/articles/3bd2957807f311</link>
-      <description>Zennからの記事: Claude Codeにコマンド一発でMCPサーバを簡単設定</description>
-      <guid>https://zenn.dev/karaage0703/articles/3bd2957807f311</guid>
-      <pubDate>Fri, 27 Jun 2025 15:35:18 +0000</pubDate>
+      <title>&lt;img src=&quot;https://zenn.dev/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;Zenn&quot;&gt; 初めてのTTSモデルをずんだもんのデータで作ってみた with LLaSA</title>
+      <link>https://zenn.dev/aratako_lm/articles/7e0b0b6e51baa6</link>
+      <description>Zennからの記事: 初めてのTTSモデルをずんだもんのデータで作ってみた with LLaSA</description>
+      <guid>https://zenn.dev/aratako_lm/articles/7e0b0b6e51baa6</guid>
+      <pubDate>Sat, 28 Jun 2025 03:00:02 +0000</pubDate>
     </item>
     <item>
       <title>&lt;img src=&quot;https://cdn.qiita.com/assets/favicons/public/production-c620d3e403342b1022967ba5e3db1aaa.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;Qiita&quot;&gt; 10歳娘「凡ミスの多い人ってプログラマーに向いてるよね」</title>

--- a/rss.xml
+++ b/rss.xml
@@ -72,11 +72,11 @@
       <pubDate>Sat, 28 Jun 2025 03:35:39 +0000</pubDate>
     </item>
     <item>
-      <title>&lt;img src=&quot;https://zenn.dev/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;Zenn&quot;&gt; 初めてのTTSモデルをずんだもんのデータで作ってみた with LLaSA</title>
-      <link>https://zenn.dev/aratako_lm/articles/7e0b0b6e51baa6</link>
-      <description>Zennからの記事: 初めてのTTSモデルをずんだもんのデータで作ってみた with LLaSA</description>
-      <guid>https://zenn.dev/aratako_lm/articles/7e0b0b6e51baa6</guid>
-      <pubDate>Sat, 28 Jun 2025 03:00:02 +0000</pubDate>
+      <title>&lt;img src=&quot;https://zenn.dev/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;Zenn&quot;&gt; Claude Codeにコマンド一発でMCPサーバを簡単設定</title>
+      <link>https://zenn.dev/karaage0703/articles/3bd2957807f311</link>
+      <description>Zennからの記事: Claude Codeにコマンド一発でMCPサーバを簡単設定</description>
+      <guid>https://zenn.dev/karaage0703/articles/3bd2957807f311</guid>
+      <pubDate>Fri, 27 Jun 2025 15:35:18 +0000</pubDate>
     </item>
     <item>
       <title>&lt;img src=&quot;https://cdn.qiita.com/assets/favicons/public/production-c620d3e403342b1022967ba5e3db1aaa.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;Qiita&quot;&gt; 10歳娘「凡ミスの多い人ってプログラマーに向いてるよね」</title>
@@ -149,6 +149,13 @@
       <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
     </item>
     <item>
+      <title>&lt;img src=&quot;https://b.hatena.ne.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;はてなブックマーク - IT（新着）&quot;&gt; Drag-and-Drop LLMs: Zero-Shot Prompt-to-Weights</title>
+      <link>https://arxiv.org/abs/2506.16406</link>
+      <description>はてなブックマーク - IT（新着）からの記事: Drag-and-Drop LLMs: Zero-Shot Prompt-to-Weights</description>
+      <guid>https://arxiv.org/abs/2506.16406</guid>
+      <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
+    </item>
+    <item>
       <title>&lt;img src=&quot;https://b.hatena.ne.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;はてなブックマーク - IT（新着）&quot;&gt; GitHub - kign/c4wa: A simplified subset of C transpiled into Web Assembly</title>
       <link>https://github.com/kign/c4wa</link>
       <description>はてなブックマーク - IT（新着）からの記事: GitHub - kign/c4wa: A simplified subset of C transpiled into Web Assembly</description>
@@ -174,13 +181,6 @@
       <link>https://zenn.dev/open_developers/articles/87928c78f98210</link>
       <description>はてなブックマーク - IT（新着）からの記事: プレゼン動画自動生成ツール Mulmocast を使う</description>
       <guid>https://zenn.dev/open_developers/articles/87928c78f98210</guid>
-      <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
-    </item>
-    <item>
-      <title>&lt;img src=&quot;https://b.hatena.ne.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;はてなブックマーク - IT（新着）&quot;&gt; o3 MCPでClaude Codeが最強の検索力を手に入れた</title>
-      <link>https://share.google/5GQ578Rnl5nQgxxj0</link>
-      <description>はてなブックマーク - IT（新着）からの記事: o3 MCPでClaude Codeが最強の検索力を手に入れた</description>
-      <guid>https://share.google/5GQ578Rnl5nQgxxj0</guid>
       <pubDate>Sun, 29 Jun 2025 00:00:00 +0000</pubDate>
     </item>
     <item>
@@ -338,6 +338,13 @@
       <pubDate>Mon, 23 Jun 2025 01:30:00 +0000</pubDate>
     </item>
     <item>
+      <title>&lt;img src=&quot;https://connpass.com/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;connpass - イベント&quot;&gt; 【限定5名増枠】英語LT会【テーマ：開発生産性】Japanglish Tech Talk#6</title>
+      <link>https://japanglish.connpass.com/event/360913/?utm_campaign=recent_events&amp;utm_source=feed&amp;utm_medium=atom</link>
+      <description>connpass - イベントからの記事: 【限定5名増枠】英語LT会【テーマ：開発生産性】Japanglish Tech Talk#6</description>
+      <guid>https://japanglish.connpass.com/event/360913/?utm_campaign=recent_events&amp;utm_source=feed&amp;utm_medium=atom</guid>
+      <pubDate>Sun, 29 Jun 2025 11:57:59 +0000</pubDate>
+    </item>
+    <item>
       <title>&lt;img src=&quot;https://connpass.com/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;connpass - イベント&quot;&gt; Djangoもくもく会: 7回目</title>
       <link>https://pythonista-books.connpass.com/event/360904/?utm_campaign=recent_events&amp;utm_source=feed&amp;utm_medium=atom</link>
       <description>connpass - イベントからの記事: Djangoもくもく会: 7回目</description>
@@ -399,13 +406,6 @@
       <description>connpass - イベントからの記事: YUMEMI × やさしい Swift 勉強会 #547 #yumemi_grow</description>
       <guid>https://yasashii-swift.connpass.com/event/360729/?utm_campaign=recent_events&amp;utm_source=feed&amp;utm_medium=atom</guid>
       <pubDate>Sun, 29 Jun 2025 04:01:09 +0000</pubDate>
-    </item>
-    <item>
-      <title>&lt;img src=&quot;https://connpass.com/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;connpass - イベント&quot;&gt; 朝活もくもく会 #23</title>
-      <link>https://zitox.connpass.com/event/360889/?utm_campaign=recent_events&amp;utm_source=feed&amp;utm_medium=atom</link>
-      <description>connpass - イベントからの記事: 朝活もくもく会 #23</description>
-      <guid>https://zitox.connpass.com/event/360889/?utm_campaign=recent_events&amp;utm_source=feed&amp;utm_medium=atom</guid>
-      <pubDate>Sun, 29 Jun 2025 03:54:24 +0000</pubDate>
     </item>
     <item>
       <title>&lt;img src=&quot;https://techplay.jp/favicon.ico&quot; width=&quot;16&quot; height=&quot;16&quot; alt=&quot;TECH PLAY - イベント&quot;&gt; 7/11(金)開催　初心者でもわかる基本用語解説セミナー</title>


### PR DESCRIPTION
Fixes #39

## 実装内容
- 動的な記事見出しを含むSlack通知機能
- GitHub Actions完了時の自動通知
- 実際のニュース記事からの注目記事ピックアップ（最大6件）
- 既存リンク（カード表示版、GitHubリポジトリ）の維持
- 総記事数のサマリー情報を追加
- 優先フィード（Tech Blog Weekly, Zenn, Qiita, はてなブックマーク）からの記事選択

## 技術的詳細
- 8398a7/action-slack@v3 を使用
- fetch_news.py でslack_message.json を生成
- GitHub Actions でJSONファイルを読み取ってSlack通知
- HTMLタグの除去とURL安全化を実装

## テスト結果
- [x] ブランチでの手動実行で動作確認済み
- [x] 動的メッセージの生成確認済み
- [x] Slack通知の送信確認済み