### PR TITLE
RSSフィードのタイトルからHTMLタグを除去

### DIFF
--- a/fetch_news.py
+++ b/fetch_news.py
@@ -771,16 +771,12 @@ def generate_rss_feed(all_entries, feed_info, date_obj):
     
     # 各フィードからアイテムを追加
     for feed_name, entries in all_entries.items():
-        favicon = feed_info[feed_name]["favicon"]
-        if favicon.startswith("http"):
-            favicon_display = f'<img src="{favicon}" width="16" height="16" alt="{feed_name}"> '
-        else:
-            favicon_display = f'{favicon} '
-            
         # エントリーはすでにURL重複除去済み
         for entry in entries:
             item = ET.SubElement(channel, 'item')
-            ET.SubElement(item, 'title').text = f'{favicon_display}{entry.title}'
+            # RSSタイトルはプレーンテキストのみ（HTMLタグや絵文字を除去）
+            clean_title = re.sub(r'<[^>]+>', '', entry.title)  # HTMLタグを除去
+            ET.SubElement(item, 'title').text = clean_title
             ET.SubElement(item, 'link').text = entry.link
             ET.SubElement(item, 'description').text = f'{feed_name}からの記事: {entry.title}'
             ET.SubElement(item, 'guid').text = entry.link


### PR DESCRIPTION
Fixes #41

## 修正内容
- RSSフィードのtitle要素からHTMLタグを完全に除去
- re.sub()でHTMLタグ除去処理を追加
- プレーンテキストのみのクリーンなタイトル表示を実現

## 修正前の問題
RSSタイトルにHTMLのimgタグがエスケープされて表示されていた

## 修正後
プレーンテキストのみのクリーンなタイトル

## 効果
- FeedlyなどのRSSリーダーでの表示品質向上
- RSS標準への準拠
- ユーザーエクスペリエンスの改善

## テスト結果
- ローカルでのRSS生成テスト完了
- HTMLタグ除去の動作確認済み