### PR TITLE
タイムゾーン問題の修正（JST基準の日付生成）

### DIFF
--- a/fetch_news.py
+++ b/fetch_news.py
@@ -878,7 +878,9 @@ def save_slack_message(slack_payload):
 
 if __name__ == "__main__":
     script_start_time = time.time()
-    today = datetime.date.today()
+    # JST（日本時間）基準で日付を取得
+    jst = datetime.timezone(datetime.timedelta(hours=9))
+    today = datetime.datetime.now(jst).date()
     
     all_entries = {}
     for name, feed_info in FEEDS.items():


### PR DESCRIPTION
## 概要
GitHub Actions実行時の日付生成がUTC基準となっており、JST 7:00実行時に前日の日付になってしまう問題を修正。

## 変更内容
- `fetch_news.py`の日付生成を`datetime.date.today()`からJST基準に変更
- `datetime.datetime.now(jst).date()`を使用してJST時刻で日付を取得

## 修正箇所
- `fetch_news.py:881-883` - JST timezone設定と日付生成

## 動作確認
- [x] JST基準の日付生成が正常に動作すること
- [x] UTC 22:00（JST 7:00）実行時に正しい日付が生成されること

## 影響範囲
- README.md タイトル
- HTML生成
- RSS feed
- アーカイブファイル
- Slack通知

Fixes #46