### PR TITLE
🐛 修正: アーカイブページの「メインページに戻る」リンクとHTML表示の問題を修正 (#43)

### DIFF
--- a/archives/2025/06/2025-06-29.html
+++ b/archives/2025/06/2025-06-29.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>今日のテックニュース (2025-06-29)</title>
+    
+    <!-- OGP Tags -->
+    <meta property="og:title" content="今日のテックニュース (2025-06-29)">
+    <meta property="og:description" content="日本の主要な技術系メディアの最新人気エントリーを毎日お届けします。">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://unsolublesugar.github.io/daily-tech-news/">
+    <meta property="og:image" content="https://unsolublesugar.github.io/daily-tech-news/assets/images/OGP.png">
+    <meta property="og:site_name" content="今日のテックニュース">
+    
+    <!-- Twitter Card Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="@unsoluble_sugar">
+    
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            line-height: 1.6;
+            color: #333;
+        }
+        h1, h2 {
+            color: #1f2328;
+        }
+        a {
+            color: #0969da;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        .rss-info {
+            background: #f6f8fa;
+            padding: 16px;
+            border-radius: 8px;
+            margin: 20px 0;
+        }
+        .footer {
+            margin-top: 40px;
+            padding: 20px 0;
+            border-top: 1px solid #e1e5e9;
+            text-align: center;
+            font-size: 14px;
+            color: #656d76;
+        }
+        .footer a {
+            color: #0969da;
+            text-decoration: none;
+        }
+        .footer a:hover {
+            text-decoration: underline;
+        }
+        ul {
+            line-height: 1.8;
+        }
+    </style>
+</head>
+<body>
+    <h1>今日のテックニュース (2025-06-29)</h1>
+    
+    <p>📚 <a href="../../index.html">過去のニュースを見る</a> | 📡 <a href="https://unsolublesugar.github.io/daily-tech-news/rss.xml">RSSフィードを購読</a></p>
+    
+    <p>日本の主要な技術系メディアの最新人気エントリーをお届けします。</p>
+    
+    <div class="rss-info">
+        <p>毎日JST 7:00に自動更新</p>
+    </div>
+    
+    <hr>
+    <h2>🎨 カード表示版もあります</h2>
+    <h2>💻 Tech Blog Weekly</h2>
+    <ul>
+        <li><a href="https://techblog.ap-com.co.jp/entry/2025/06/29/180121">ByteDanceはIcebergとMosaic Streamingをどう拡張したか？大規模ML基盤「Magnus Lake」と「ByteD Streaming」の全貌 | APC 技術ブログ</a></li>
+        <li><a href="https://techblog.ap-com.co.jp/entry/2025/06/29/150245">AWS Summit Japan 2025に参加してGitLab Duo with Amazon Qのセッションを聞いてきた | APC 技術ブログ</a></li>
+        <li><a href="https://www.m3tech.blog/entry/2025/06/29/110000">「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに | エムスリーテックブログ</a></li>
+        <li><a href="https://developers.cyberagent.co.jp/blog/archives/57070/">新卒1年目が挑む！！十数万リクエストに耐える Contextual Bandit を用いたレコメンドシステムの構築 ~ バックエンド編 ~ | CyberAgent Developers Blog | サイバーエージェント デベロッパーズブログ</a></li>
+        <li><a href="https://note.shiftinc.jp/n/ndb8b94f1fc7e">20日で鍛える読解力：Day14｜「なんか引っかかる」を見逃さない | SHIFT Group 技術ブログ</a></li>
+    </ul>
+    <hr>
+    <h2><img src="https://zenn.dev/favicon.ico" width="16" height="16" alt="Zenn"> Zenn</h2>
+    <ul>
+        <li><a href="https://zenn.dev/labcode/books/71b01f2557419e">【初心者向け】各種ツールで学ぶin silicoタンパク質デザイン 〜新規デザインから物性評価まで~</a></li>
+        <li><a href="https://zenn.dev/mascii/articles/joy-con-2-web-bluetooth-api">【Web Bluetooth API】Joy-Con 2 をプレゼンリモコンにする</a></li>
+        <li><a href="https://zenn.dev/oikon/articles/c8a887f00dd219">Gemini CLIをソース解析して発見したコーギーの出現方法</a></li>
+        <li><a href="https://zenn.dev/grandchildrice/articles/499e22b0e9e4c8">AIエージェントでバグバウンティ！ Cline × Claude Code × GPT-o3 で $2,000 を獲得した話</a></li>
+        <li><a href="https://zenn.dev/aratako_lm/articles/7e0b0b6e51baa6">初めてのTTSモデルをずんだもんのデータで作ってみた with LLaSA</a></li>
+    </ul>
+    <hr>
+    <h2><img src="https://cdn.qiita.com/assets/favicons/public/production-c620d3e403342b1022967ba5e3db1aaa.ico" width="16" height="16" alt="Qiita"> Qiita</h2>
+    <ul>
+        <li><a href="https://qiita.com/mkt_hanada/items/04c9e040c8b4131a3948?utm_campaign=popular_items&utm_medium=feed&utm_source=popular_items">【ご報告】遠距離恋愛にアジャイルを応用して結婚しました</a></li>
+        <li><a href="https://qiita.com/omochi_0604/items/676bc3f123bc24d3602b?utm_campaign=popular_items&utm_medium=feed&utm_source=popular_items">「公共Wi-Fiは危険」ってよく聞くけど… どこがどう危ないの？物理から紐解くセキュリティ入門</a></li>
+        <li><a href="https://qiita.com/Yametaro/items/0b241519dc6b416474c5?utm_campaign=popular_items&utm_medium=feed&utm_source=popular_items">10歳娘「凡ミスの多い人ってプログラマーに向いてるよね」</a></li>
+        <li><a href="https://qiita.com/issy929/items/e02154bea72c4cff3106?utm_campaign=popular_items&utm_medium=feed&utm_source=popular_items">AWS Summit 2025 Community Stage全セッション＆資料まとめ</a></li>
+    </ul>
+    <hr>
+    <h2><img src="https://b.hatena.ne.jp/favicon.ico" width="16" height="16" alt="はてなブックマーク - IT（人気）"> はてなブックマーク - IT（人気）</h2>
+    <ul>
+        <li><a href="https://zenn.dev/sesere/articles/0420ecec9526dc">Claude Codeの「すぐルール忘れる問題」を解決する超効果的な方法を見つけた気がする</a></li>
+        <li><a href="https://togetter.com/li/2569663">「アホのファイル転送(PC2台をLANケーブルで直結)」→実はデータ移行ではワイヤレート近くが出るので便利「仕事でoutlookのファイルサイズが異常に大きい客が居た時に有用」</a></li>
+        <li><a href="https://zenn.dev/open_developers/articles/87928c78f98210">プレゼン動画自動生成ツール Mulmocast を使う</a></li>
+        <li><a href="https://togetter.com/li/2569535">授業参観に行ったらネットリテラシー講座がセキュリティソフトの営業会場になっていた話</a></li>
+        <li><a href="https://arclamp.hatenablog.com/entry/2025/06/26/213143">フルスタックエンジニアの終焉？生成AI後の未来を産業史から考える - arclamp</a></li>
+    </ul>
+    <hr>
+    <h2><img src="https://b.hatena.ne.jp/favicon.ico" width="16" height="16" alt="はてなブックマーク - IT（新着）"> はてなブックマーク - IT（新着）</h2>
+    <ul>
+        <li><a href="https://www.nikkei.com/article/DGXZQOUC13BCW0T10C25A6000000/">論文内に秘密の命令文、AIに「高評価せよ」　日韓米など有力14大学で - 日本経済新聞</a></li>
+        <li><a href="https://forest.watch.impress.co.jp/docs/news/2026720.html">「Windows 11 バージョン 25H2」のテストが開始、正式リリースは2025年後半／次期機能更新プログラム、「バージョン 24H2」とはコード共通で「eKB」による切り替え</a></li>
+        <li><a href="https://note.com/genkaijokyo/n/nfb96a13e084f">なぜ今、研究者はGeminiを選ぶべきか？他のAIとの比較で見る10のメリット｜genkAIjokyo|ChatGPT/Claudeで論文作成と科研費申請</a></li>
+        <li><a href="https://www.publickey1.jp/blog/25/visual_studio_codeaigithub_copilot_chat.html">Visual Studio CodeのAIエディタ化が前進、GitHub Copilot Chatがオープンソースで公開。現在プレリリース版</a></li>
+        <li><a href="https://github.com/microsoft/vscode-copilot-chat">GitHub - microsoft/vscode-copilot-chat: Copilot Chat extension for VS Code</a></li>
+    </ul>
+    <hr>
+    <h2><img src="https://dev.classmethod.jp/favicon.ico" width="16" height="16" alt="DevelopersIO"> DevelopersIO</h2>
+    <ul>
+        <li><a href="https://dev.classmethod.jp/articles/waf-protection-pack/">AWS WAF 新コンソールの「保護パック」を新規作成する時に、何をどう選択したら良いのか調べてみた</a></li>
+        <li><a href="https://dev.classmethod.jp/articles/amazon-connect-customer-profiles-profile-list/">Amazon Connect Customer Profilesに登録された全顧客の一覧を取得する方法</a></li>
+        <li><a href="https://dev.classmethod.jp/articles/amazon-q-cli-mini-factrio/">Amazon Q CLIで鉄鉱石採掘体験ゲームを作ってみた #AmazonQCLI</a></li>
+        <li><a href="https://dev.classmethod.jp/articles/amazon-connect-outbound-campaigns-three-regions/">Amazon Connect アウトバウンドキャンペーンが東京リージョンで利用可能になりました</a></li>
+    </ul>
+    <hr>
+    <h2><img src="https://gihyo.jp/favicon.ico" width="16" height="16" alt="gihyo.jp"> gihyo.jp</h2>
+    <ul>
+        <li><a href="https://gihyo.jp/article/2025/06/claude-desktop-extensions?utm_source=feed">Anthropic、ワンクリックでローカルMCPサーバーをインストールできる「Desktop Extensions」をリリース</a></li>
+        <li><a href="https://gihyo.jp/article/2025/06/color-me-shop-day-2025?utm_source=feed">GMOペパボ、ECサイト運営者を対象にした参加費無料のオンライントークイベント「COLOR ME SHOP DAY 2025」を7月24日に開催</a></li>
+        <li><a href="https://gihyo.jp/article/2025/06/google-gemma-3n?utm_source=feed">Google、Gemma 3nをリリース ―エッジデバイスでの動作効率が大幅アップ、フレキシブルなマルチモーダルモデル</a></li>
+        <li><a href="https://gihyo.jp/admin/clip/01/ubuntu-topics/202506/27?utm_source=feed">MediaTek Genio向けのUbuntu Core、Ubuntu 25.10（questing）の開発; 新しいゴミ箱アイコンとServer Seedの見直し</a></li>
+        <li><a href="https://gihyo.jp/article/2025/06/fastly-tyler-mcmullen?utm_source=feed">最大の差別化要因はWebAssemblyの採用 ―― Fastly共同創業者Tyler McMullen氏に聞く次世代CDNの最前線</a></li>
+    </ul>
+    <hr>
+    <h2><img src="https://www.publickey1.jp/favicon.ico" width="16" height="16" alt="Publickey"> Publickey</h2>
+    <ul>
+        <li><a href="https://www.publickey1.jp/blog/25/android_studiogeminiai.html">Android StudioでGeminiのエージェントモードが利用可能に。「ダークモードを追加して」などの指示でAIが自律コーディング</a></li>
+        <li><a href="https://www.publickey1.jp/blog/25/awsgoogleaiagent2agentlinux_foundation.html">AWS、Google、マイクロソフトらがAIエージェント連携のため「Agent2Agentプロジェクト」設立。Linux Foundation傘下で</a></li>
+        <li><a href="https://www.publickey1.jp/blog/25/cloudflareworkers_kvgoogle_cloudgoogle_cloud.html">Cloudflareが重大なサービス障害の原因を説明。実はWorkers KVがGoogle Cloudに依存しており、Google Cloudの障害が原因だったと</a></li>
+        <li><a href="https://www.publickey1.jp/blog/25/pcpcwindows_365_reserve.html">マイクロソフト、PCの紛失や故障などのとき一時的に同構成のクラウドPCが使える「Windows 365 Reserve」プレビュー公開</a></li>
+        <li><a href="https://www.publickey1.jp/blog/25/cve_foundation.html">CVE Foundationが取締役会と今後の計画を明らかに。安定性のために複数の収入源による財務基盤を確立など</a></li>
+    </ul>
+    <hr>
+    <h2><img src="https://codezine.jp/favicon.ico" width="16" height="16" alt="CodeZine"> CodeZine</h2>
+    <ul>
+        <li><a href="http://codezine.jp/article/detail/21798">メシウス、PDFファイル内の表をExcelで出力できるドキュメントAPIライブラリの最新版をリリース</a></li>
+        <li><a href="http://codezine.jp/article/detail/21802">Linux Foundation、「Agent2Agentプロジェクト」の設立を発表</a></li>
+        <li><a href="http://codezine.jp/article/detail/21803">Google、Android StudioのGeminiにエージェント機能を追加</a></li>
+        <li><a href="http://codezine.jp/article/detail/21433">バックエンドの知識が活きるReact入門──オブジェクト指向で学ぶフロントエンド</a></li>
+        <li><a href="http://codezine.jp/article/detail/21795">電通総研、AWS移行を評価から運用まで支援 構築後の生成AI活用も</a></li>
+    </ul>
+    <hr>
+    <h2><img src="https://www.infoq.com/favicon.ico" width="16" height="16" alt="InfoQ Japan"> InfoQ Japan</h2>
+    <ul>
+        <li><a href="https://www.infoq.com/jp/news/2025/06/amazon-q-cli-claude-code/?utm_campaign=infoq_content&utm_source=infoq&utm_medium=feed&utm_term=global">Amazon QとClaude Codeが開発者CLIをAIで制御可能に</a></li>
+        <li><a href="https://www.infoq.com/jp/news/2025/06/cisco-jarvis-ai-assistant/?utm_campaign=infoq_content&utm_source=infoq&utm_medium=feed&utm_term=global">CiscoがJARVISを発表：プラットフォームエンジニアリングチームのためのAIアシスタント</a></li>
+    </ul>
+    <hr>
+    <h2><img src="https://connpass.com/favicon.ico" width="16" height="16" alt="connpass - イベント"> connpass - イベント</h2>
+    <ul>
+        <li><a href="https://engineercafe.connpass.com/event/360029/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom">ハードウェア技術誌を読もう：トランジスタ技術最新号よみあわせ解説会(2025年9月号)</a></li>
+        <li><a href="https://engineercafe.connpass.com/event/360005/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom">ハードウェア技術誌を読もう：トランジスタ技術最新号よみあわせ解説会(2025年8月号)</a></li>
+        <li><a href="https://machine-learning15minutes.connpass.com/event/360928/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom">第103回 Machine Learning 15minutes! Hybrid</a></li>
+        <li><a href="https://engineercafe.connpass.com/event/358631/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom">Arduino Uno R4ボードを設計しようプロジェクト #1</a></li>
+        <li><a href="https://758indies.connpass.com/event/360927/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom">第131回 なごや個人開発者の集い</a></li>
+        <li><a href="https://elem-ukrainian.connpass.com/event/360925/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom">『初級ウクライナ語文法』勉強会(17)</a></li>
+        <li><a href="https://shikumirb.connpass.com/event/360924/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom">Shikumi.rb #7</a></li>
+        <li><a href="https://xpreadinggroup.connpass.com/event/360917/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom">Tidy First?会読会 第4回</a></li>
+        <li><a href="https://japanglish.connpass.com/event/360913/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom">【限定5名増枠】英語LT会【テーマ：開発生産性】Japanglish Tech Talk#6</a></li>
+        <li><a href="https://pythonista-books.connpass.com/event/360904/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom">Djangoもくもく会: 7回目</a></li>
+    </ul>
+    <hr>
+    <h2><img src="https://techplay.jp/favicon.ico" width="16" height="16" alt="TECH PLAY - イベント"> TECH PLAY - イベント</h2>
+    <ul>
+        <li><a href="https://techplay.jp/event/983108">SnowVillage Unconference #6　– 初心者大歓迎！聞き専/飛入登壇, ご自由なスタイルで！</a></li>
+        <li><a href="https://techplay.jp/event/983102">7/11(金)開催　初心者でもわかる基本用語解説セミナー</a></li>
+        <li><a href="https://techplay.jp/event/983101">Instagram×LINEで売上130%UP ～フォロワーの価値を最大化させる3つのポイント～</a></li>
+        <li><a href="https://techplay.jp/event/983084">07/05 Power BI 実演ライブ #9｜米の消費/需給データ</a></li>
+        <li><a href="https://techplay.jp/event/983055">【定員5人】GA4 × サーチコンソール × AI分析 × LLMO(AI検索最適化)準備 × 投資対効果も解説！可視化と自走を両立 ― これから始める「分析体制構築」不透明な未来に強固な仕組みを【別日開催あり】</a></li>
+        <li><a href="https://techplay.jp/event/982480">〜Tableau tuneup Vol.15 ~初心者相談室×Tabもく会~</a></li>
+        <li><a href="https://techplay.jp/event/983092">ネットワークハンズオン（CCNA実習、AWS接続・L3スイッチ・ファイアウォール実習）</a></li>
+        <li><a href="https://techplay.jp/event/982852">AWS Discovery Day 2025 in Winスクール</a></li>
+        <li><a href="https://techplay.jp/event/983086">独学もオンラインも無理だから「永田町Pythonミニキャンプ」【5日間5万円】</a></li>
+        <li><a href="https://techplay.jp/event/982897">【オンライン参加OK！】インフラエンジニア向けキャリア勉強会</a></li>
+    </ul>
+    <hr>
+    <h2><img src="https://www.oreilly.co.jp/favicon.ico" width="16" height="16" alt="O'Reilly Japan - 近刊"> O'Reilly Japan - 近刊</h2>
+    <ul>
+        <li><a href="http://www.oreilly.co.jp/books/9784814401093/?utm_source=feed&utm_mediun=referral&utm_content=new_book">Effective TypeScript 第2版</a></li>
+        <li><a href="http://www.oreilly.co.jp/books/9784814401130/?utm_source=feed&utm_mediun=referral&utm_content=new_book">LLMのプロンプトエンジニアリング</a></li>
+        <li><a href="http://www.oreilly.co.jp/books/9784814400997/?utm_source=feed&utm_mediun=referral&utm_content=new_book">micro:bitではじめるAI工作</a></li>
+        <li><a href="http://www.oreilly.co.jp/books/9784814401222/?utm_source=feed&utm_mediun=referral&utm_content=new_book">PythonによるWebスクレイピング 第3版</a></li>
+        <li><a href="http://www.oreilly.co.jp/books/9784814401185/?utm_source=feed&utm_mediun=referral&utm_content=new_book">Async Rust</a></li>
+    </ul>
+    <hr>
+
+    <div class="footer">
+        <p>🚀 運営者: <a href="https://x.com/unsoluble_sugar" target="_blank" rel="noopener">@unsoluble_sugar</a> | 
+        📁 <a href="https://github.com/unsolublesugar/daily-tech-news" target="_blank" rel="noopener">GitHub Repository</a></p>
+    </div>
+</body>
+</html>

--- a/archives/2025/06/2025-06-30.html
+++ b/archives/2025/06/2025-06-30.html
@@ -1,0 +1,786 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>今日のテックニュース (2025-06-30)</title>
+    
+    <!-- OGP Tags -->
+    <meta property="og:title" content="今日のテックニュース (2025-06-30)">
+    <meta property="og:description" content="日本の主要な技術系メディアの最新人気エントリーを毎日お届けします。">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://unsolublesugar.github.io/daily-tech-news/">
+    <meta property="og:image" content="https://unsolublesugar.github.io/daily-tech-news/assets/images/OGP.png">
+    <meta property="og:site_name" content="今日のテックニュース">
+    
+    <!-- Twitter Card Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="@unsoluble_sugar">
+    
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            line-height: 1.6;
+            color: #333;
+        }
+        .card {
+            border: 1px solid #e1e5e9;
+            padding: 15px;
+            margin: 15px 0;
+            border-radius: 8px;
+            background-color: #f8f9fa;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            transition: box-shadow 0.2s ease;
+            text-decoration: none;
+            color: inherit;
+            display: block;
+        }
+        .card:hover {
+            box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+        }
+        .card-content {
+            display: flex;
+            align-items: flex-start;
+            gap: 15px;
+        }
+        .card-image {
+            border-radius: 6px;
+            object-fit: cover;
+            flex-shrink: 0;
+        }
+        .card-text {
+            flex: 1;
+        }
+        .card-title {
+            margin: 0 0 8px 0;
+            font-size: 16px;
+            line-height: 1.4;
+            color: #0969da;
+            font-weight: 600;
+        }
+        .card-source {
+            margin: 0;
+            font-size: 12px;
+            color: #656d76;
+        }
+        h1, h2 {
+            color: #1f2328;
+        }
+        .rss-info {
+            background: #f6f8fa;
+            padding: 16px;
+            border-radius: 8px;
+            margin: 20px 0;
+        }
+        .footer {
+            margin-top: 40px;
+            padding: 20px 0;
+            border-top: 1px solid #e1e5e9;
+            text-align: center;
+            font-size: 14px;
+            color: #656d76;
+        }
+        .footer a {
+            color: #0969da;
+            text-decoration: none;
+        }
+        .footer a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <h1>今日のテックニュース (2025-06-30)</h1>
+    
+    <p>📚 <a href="../../index.html">過去のニュースを見る</a> | 📡 <a href="https://unsolublesugar.github.io/daily-tech-news/rss.xml">RSSフィードを購読</a></p>
+    
+    <p>日本の主要な技術系メディアの最新人気エントリーをお届けします。</p>
+    
+    <div class="rss-info">
+        <p>毎日JST 7:00に自動更新</p>
+    </div>
+    
+    <hr>
+    <h2>💻 Tech Blog Weekly</h2>
+    <a href="https://developers.cyberagent.co.jp/blog/archives/56935/" class="card">
+        <div class="card-content">
+            <img src="https://developers.cyberagent.co.jp/blog/wp-content/themes/onepress-child/assets/images/og/og.png" width="120" height="90" alt="「CL」 iOS 多言語化戦略 オンデバイス翻訳導入事例 | CyberAgent Developers Blog | サイバーエージェント デベロッパーズブログ" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">「CL」 iOS 多言語化戦略 オンデバイス翻訳導入事例 | CyberAgent Developers Blog | サイバーエージェント デベロッパーズブログ</h4>
+                <p class="card-source">Tech Blog Weekly</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://tech.forstartups.com/entry/2025/06/30/080000" class="card">
+        <div class="card-content">
+            <img src="https://cdn.image.st-hatena.com/image/scale/c03c382cc32db2a4c6e35168eb7e8b76bd9ca99f/backend=imagemagick;version=1;width=1300/https%3A%2F%2Fcdn-ak.f.st-hatena.com%2Fimages%2Ffotolife%2Fr%2Fryo_takaba%2F20250616%2F20250616115127.png" width="120" height="90" alt="DuckDB + GrafanaでELBのログをSQLライクに集計する | for Startups Tech blog" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">DuckDB + GrafanaでELBのログをSQLライクに集計する | for Startups Tech blog</h4>
+                <p class="card-source">Tech Blog Weekly</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://tech.findy.co.jp/entry/2025/06/30/070000" class="card">
+        <div class="card-content">
+            <img src="https://cdn.image.st-hatena.com/image/scale/6a9ff1e0bd0f7c70615e487eae3325063889c405/backend=imagemagick;version=1;width=1300/https%3A%2F%2Fcdn-ak.f.st-hatena.com%2Fimages%2Ffotolife%2Fs%2Fshoota-dev%2F20250626%2F20250626110538.png" width="120" height="90" alt="60万行を超えるフロントエンドのリアーキテクチャとCI戦略 | Findy Tech Blog" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">60万行を超えるフロントエンドのリアーキテクチャとCI戦略 | Findy Tech Blog</h4>
+                <p class="card-source">Tech Blog Weekly</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://tech.dentsusoken.com/entry/2025/06/30/40%E4%BB%A3%E9%96%8B%E7%99%BA%E3%83%9E%E3%83%8D%E3%83%BC%E3%82%B8%E3%83%A3%E3%81%AE%E7%B6%99%E7%B6%9A%E7%9A%84%E3%82%A2%E3%83%83%E3%83%97%E3%82%B9%E3%82%AD%E3%83%AA%E3%83%B3%E3%82%B0%EF%BC%88AWS%E5%85%A8" class="card">
+        <div class="card-content">
+            <img src="https://cdn.image.st-hatena.com/image/scale/67b4e2468319c1d661447b5436c2a709ad9365a5/backend=imagemagick;version=1;width=1300/https%3A%2F%2Fcdn.user.blog.st-hatena.com%2Fdefault_entry_og_image%2F158529656%2F1704872217353595" width="120" height="90" alt="40代開発マネージャの継続的アップスキリング（AWS全冠→2年連続Japan All AWS Certifications Engineers選出） | 電通総研 テックブログ" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">40代開発マネージャの継続的アップスキリング（AWS全冠→2年連続Japan All AWS Certifications Engineers選出） | 電通総研 テックブログ</h4>
+                <p class="card-source">Tech Blog Weekly</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://tech.dentsusoken.com/entry/2025/06/30/%E3%82%B7%E3%82%B9%E3%83%86%E3%83%A0%E3%83%A9%E3%82%A4%E3%83%95%E3%82%B5%E3%82%A4%E3%82%AF%E3%83%AB%E3%83%97%E3%83%AD%E3%82%BB%E3%82%B9%E3%81%AB%E3%81%8A%E3%81%91%E3%82%8B%E3%82%BB%E3%82%AD%E3%83%A5" class="card">
+        <div class="card-content">
+            <img src="https://cdn.image.st-hatena.com/image/scale/55608f7d69b9a4c4135cc2f8e82e3db094618074/backend=imagemagick;version=1;width=1300/https%3A%2F%2Fcdn-ak.f.st-hatena.com%2Fimages%2Ffotolife%2Fd%2Fdentsusoken%2F20250610%2F20250610103637.png" width="120" height="90" alt="システムライフサイクルプロセスにおけるセキュリティ | 電通総研 テックブログ" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">システムライフサイクルプロセスにおけるセキュリティ | 電通総研 テックブログ</h4>
+                <p class="card-source">Tech Blog Weekly</p>
+            </div>
+        </div>
+    </a>
+    <hr>
+    <h2><img src="https://zenn.dev/favicon.ico" width="16" height="16" alt="Zenn"> Zenn</h2>
+    <a href="https://zenn.dev/labcode/books/71b01f2557419e" class="card">
+        <div class="card-content">
+            <img src="https://res.cloudinary.com/zenn/image/upload/s--hVSn0swi--/g_center%2Ch_280%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYm9va19jb3Zlci9mY2JjM2QxNjZlLnBuZw==%2Cw_200/v1627283836/default/og-base-book_yz4z02.jpg" width="120" height="90" alt="【初心者向け】各種ツールで学ぶin silicoタンパク質デザイン 〜新規デザインから物性評価まで~" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">【初心者向け】各種ツールで学ぶin silicoタンパク質デザイン 〜新規デザインから物性評価まで~</h4>
+                <p class="card-source">Zenn</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://zenn.dev/mascii/articles/joy-con-2-web-bluetooth-api" class="card">
+        <div class="card-content">
+            <img src="https://res.cloudinary.com/zenn/image/upload/s--tTeK7JE2--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:%25E3%2580%2590Web%2520Bluetooth%2520API%25E3%2580%2591Joy-Con%25202%2520%25E3%2582%2592%25E3%2583%2597%25E3%2583%25AC%25E3%2582%25BC%25E3%2583%25B3%25E3%2583%25AA%25E3%2583%25A2%25E3%2582%25B3%25E3%2583%25B3%25E3%2581%25AB%25E3%2581%2599%25E3%2582%258B%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_37:mascii%2Cx_203%2Cy_121/g_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyL2M5M2MwYzIzMDMuanBlZw==%2Cr_max%2Cw_90%2Cx_87%2Cy_95/v1627283836/default/og-base-w1200-v2.png" width="120" height="90" alt="【Web Bluetooth API】Joy-Con 2 をプレゼンリモコンにする" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">【Web Bluetooth API】Joy-Con 2 をプレゼンリモコンにする</h4>
+                <p class="card-source">Zenn</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://zenn.dev/oikon/articles/c8a887f00dd219" class="card">
+        <div class="card-content">
+            <img src="https://res.cloudinary.com/zenn/image/upload/s--AJmfXz3q--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:Gemini%2520CLI%25E3%2582%2592%25E3%2582%25BD%25E3%2583%25BC%25E3%2582%25B9%25E8%25A7%25A3%25E6%259E%2590%25E3%2581%2597%25E3%2581%25A6%25E7%2599%25BA%25E8%25A6%258B%25E3%2581%2597%25E3%2581%259F%25E3%2582%25B3%25E3%2583%25BC%25E3%2582%25AE%25E3%2583%25BC%25E3%2581%25AE%25E5%2587%25BA%25E7%258F%25BE%25E6%2596%25B9%25E6%25B3%2595%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_37:Oikon%2Cx_203%2Cy_121/g_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzFlNjI2MjNlZTQuanBlZw==%2Cr_max%2Cw_90%2Cx_87%2Cy_95/v1627283836/default/og-base-w1200-v2.png" width="120" height="90" alt="Gemini CLIをソース解析して発見したコーギーの出現方法" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">Gemini CLIをソース解析して発見したコーギーの出現方法</h4>
+                <p class="card-source">Zenn</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://zenn.dev/grandchildrice/articles/499e22b0e9e4c8" class="card">
+        <div class="card-content">
+            <img src="https://res.cloudinary.com/zenn/image/upload/s--Ynwwu7jL--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:AI%25E3%2582%25A8%25E3%2583%25BC%25E3%2582%25B8%25E3%2582%25A7%25E3%2583%25B3%25E3%2583%2588%25E3%2581%25A7%25E3%2583%2590%25E3%2582%25B0%25E3%2583%2590%25E3%2582%25A6%25E3%2583%25B3%25E3%2583%2586%25E3%2582%25A3%25EF%25BC%2581%2520Cline%2520%25C3%2597%2520Claude%2520Code%2520%25C3%2597%2520GPT-o3%2520%25E3%2581%25A7%2520%25242%252C000%2520%25E3%2582%2592...%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_37:gohan%2Cx_203%2Cy_121/g_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9saDMuZ29vZ2xldXNlcmNvbnRlbnQuY29tL2EvQUNnOG9jSjNHNUJxRkUyT2FTVER3ZHAyVldkdGJnY1RNV1cwYmlhbnBEZl9ZTUdqUE9TZ3h0TUQ9czk2LWM=%2Cr_max%2Cw_90%2Cx_87%2Cy_95/v1627283836/default/og-base-w1200-v2.png" width="120" height="90" alt="AIエージェントでバグバウンティ！ Cline × Claude Code × GPT-o3 で $2,000 を獲得した話" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">AIエージェントでバグバウンティ！ Cline × Claude Code × GPT-o3 で $2,000 を獲得した話</h4>
+                <p class="card-source">Zenn</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://zenn.dev/aratako_lm/articles/7e0b0b6e51baa6" class="card">
+        <div class="card-content">
+            <img src="https://res.cloudinary.com/zenn/image/upload/s--y-bx69F2--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:%25E5%2588%259D%25E3%2582%2581%25E3%2581%25A6%25E3%2581%25AETTS%25E3%2583%25A2%25E3%2583%2587%25E3%2583%25AB%25E3%2582%2592%25E3%2581%259A%25E3%2582%2593%25E3%2581%25A0%25E3%2582%2582%25E3%2582%2593%25E3%2581%25AE%25E3%2583%2587%25E3%2583%25BC%25E3%2582%25BF%25E3%2581%25A7%25E4%25BD%259C%25E3%2581%25A3%25E3%2581%25A6%25E3%2581%25BF%25E3%2581%259F%2520with%2520LLaSA%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_37:Aratako%2Cx_203%2Cy_121/g_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzY1MThmOTRmNmEuanBlZw==%2Cr_max%2Cw_90%2Cx_87%2Cy_95/v1627283836/default/og-base-w1200-v2.png" width="120" height="90" alt="初めてのTTSモデルをずんだもんのデータで作ってみた with LLaSA" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">初めてのTTSモデルをずんだもんのデータで作ってみた with LLaSA</h4>
+                <p class="card-source">Zenn</p>
+            </div>
+        </div>
+    </a>
+    <hr>
+    <h2><img src="https://cdn.qiita.com/assets/favicons/public/production-c620d3e403342b1022967ba5e3db1aaa.ico" width="16" height="16" alt="Qiita"> Qiita</h2>
+    <a href="https://qiita.com/mkt_hanada/items/04c9e040c8b4131a3948?utm_campaign=popular_items&utm_medium=feed&utm_source=popular_items" class="card">
+        <div class="card-content">
+            <img src="https://qiita-user-contents.imgix.net/https%3A%2F%2Fqiita-user-contents.imgix.net%2Fhttps%253A%252F%252Fcdn.qiita.com%252Fassets%252Fpublic%252Farticle-ogp-background-afbab5eb44e0b055cce1258705637a91.png%3Fixlib%3Drb-4.0.0%26w%3D1200%26blend64%3DaHR0cHM6Ly9xaWl0YS11c2VyLXByb2ZpbGUtaW1hZ2VzLmltZ2l4Lm5ldC9odHRwcyUzQSUyRiUyRnFpaXRhLWltYWdlLXN0b3JlLnMzLmFwLW5vcnRoZWFzdC0xLmFtYXpvbmF3cy5jb20lMkYwJTJGNjE2NDk2JTJGcHJvZmlsZS1pbWFnZXMlMkYxNzExNTAzODIxP2l4bGliPXJiLTQuMC4wJmFyPTElM0ExJmZpdD1jcm9wJm1hc2s9ZWxsaXBzZSZmbT1wbmczMiZzPWZhNjhhNjg5MDZhYjE5YzAzMWIwNjdhYmExMGE0YTNi%26blend-x%3D120%26blend-y%3D467%26blend-w%3D82%26blend-h%3D82%26blend-mode%3Dnormal%26s%3D5dc3084850ff37c3a2468fef88a67834?ixlib=rb-4.0.0&w=1200&fm=jpg&mark64=aHR0cHM6Ly9xaWl0YS11c2VyLWNvbnRlbnRzLmltZ2l4Lm5ldC9-dGV4dD9peGxpYj1yYi00LjAuMCZ3PTk2MCZoPTMyNCZ0eHQ9JUUzJTgwJTkwJUUzJTgxJTk0JUU1JUEwJUIxJUU1JTkxJThBJUUzJTgwJTkxJUU5JTgxJUEwJUU4JUI3JTlEJUU5JTlCJUEyJUU2JTgxJThCJUU2JTg0JTlCJUUzJTgxJUFCJUUzJTgyJUEyJUUzJTgyJUI4JUUzJTgzJUEzJUUzJTgyJUE0JUUzJTgzJUFCJUUzJTgyJTkyJUU1JUJGJTlDJUU3JTk0JUE4JUUzJTgxJTk3JUUzJTgxJUE2JUU3JUI1JTkwJUU1JUE5JTlBJUUzJTgxJTk3JUUzJTgxJUJFJUUzJTgxJTk3JUUzJTgxJTlGJnR4dC1hbGlnbj1sZWZ0JTJDdG9wJnR4dC1jb2xvcj0lMjMxRTIxMjEmdHh0LWZvbnQ9SGlyYWdpbm8lMjBTYW5zJTIwVzYmdHh0LXNpemU9NTYmdHh0LXBhZD0wJnM9YTU0MzRiODNkOWVhZDU0YmJiMDJlZDE4MzdjMjRhYmI&mark-x=120&mark-y=112&blend64=aHR0cHM6Ly9xaWl0YS11c2VyLWNvbnRlbnRzLmltZ2l4Lm5ldC9-dGV4dD9peGxpYj1yYi00LjAuMCZ3PTgzOCZoPTU4JnR4dD0lNDBta3RfaGFuYWRhJnR4dC1jb2xvcj0lMjMxRTIxMjEmdHh0LWZvbnQ9SGlyYWdpbm8lMjBTYW5zJTIwVzYmdHh0LXNpemU9MzYmdHh0LXBhZD0wJnM9ODUzZTExNDlkMmRmZTQ3ZWI1MjNkMGQ0MWRiOGViMGE&blend-x=242&blend-y=480&blend-w=838&blend-h=46&blend-fit=crop&blend-crop=left%2Cbottom&blend-mode=normal&s=290f418b953f9308344d327ec07298ef" width="120" height="90" alt="【ご報告】遠距離恋愛にアジャイルを応用して結婚しました" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">【ご報告】遠距離恋愛にアジャイルを応用して結婚しました</h4>
+                <p class="card-source">Qiita</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://qiita.com/omochi_0604/items/676bc3f123bc24d3602b?utm_campaign=popular_items&utm_medium=feed&utm_source=popular_items" class="card">
+        <div class="card-content">
+            <img src="https://qiita-user-contents.imgix.net/https%3A%2F%2Fqiita-user-contents.imgix.net%2Fhttps%253A%252F%252Fcdn.qiita.com%252Fassets%252Fpublic%252Ftech-festa-ogp-background-4b5015b2c518c7e6b9062a7c9f5f5e90.png%3Fixlib%3Drb-4.0.0%26w%3D1200%26blend64%3DaHR0cHM6Ly9xaWl0YS11c2VyLXByb2ZpbGUtaW1hZ2VzLmltZ2l4Lm5ldC9odHRwcyUzQSUyRiUyRnFpaXRhLWltYWdlLXN0b3JlLnMzLmFwLW5vcnRoZWFzdC0xLmFtYXpvbmF3cy5jb20lMkYwJTJGMjI3MzYzOCUyRnByb2ZpbGUtaW1hZ2VzJTJGMTc1MDMwOTc3OT9peGxpYj1yYi00LjAuMCZhcj0xJTNBMSZmaXQ9Y3JvcCZtYXNrPWVsbGlwc2UmZm09cG5nMzImcz01ZTc1MTQxZGNmM2VjY2JmZWFiZTFkMTgyYzA0NjI0NA%26blend-x%3D120%26blend-y%3D467%26blend-w%3D82%26blend-h%3D82%26blend-mode%3Dnormal%26s%3D881b920404f593a2a340efd54d98b3cc?ixlib=rb-4.0.0&w=1200&fm=jpg&mark64=aHR0cHM6Ly9xaWl0YS11c2VyLWNvbnRlbnRzLmltZ2l4Lm5ldC9-dGV4dD9peGxpYj1yYi00LjAuMCZ3PTk2MCZoPTMyNCZ0eHQ9JUUzJTgwJThDJUU1JTg1JUFDJUU1JTg1JUIxV2ktRmklRTMlODElQUYlRTUlOEQlQjElRTklOTklQkElRTMlODAlOEQlRTMlODElQTMlRTMlODElQTYlRTMlODIlODglRTMlODElOEYlRTglODElOUUlRTMlODElOEYlRTMlODElOTElRTMlODElQTklRTIlODAlQTYlMjAlRTMlODElQTklRTMlODElOTMlRTMlODElOEMlRTMlODElQTklRTMlODElODYlRTUlOEQlQjElRTMlODElQUElRTMlODElODQlRTMlODElQUUlRUYlQkMlOUYlRTclODklQTklRTclOTAlODYlRTMlODElOEIlRTMlODIlODklRTclQjQlOTAlRTglQTclQTMlRTMlODElOEYlRTMlODIlQkIlRTMlODIlQUQlRTMlODMlQTUlRTMlODMlQUElRTMlODMlODYlRTMlODIlQTMlRTUlODUlQTUlRTklOTYlODAmdHh0LWFsaWduPWxlZnQlMkN0b3AmdHh0LWNvbG9yPSUyM0ZGRkZGRiZ0eHQtZm9udD1IaXJhZ2lubyUyMFNhbnMlMjBXNiZ0eHQtc2l6ZT01NiZ0eHQtcGFkPTAmcz05ZTljZGM1OGQ4YzRjMDYwODJhM2Q0NjYwNWI0NmNjMA&mark-x=120&mark-y=112&blend64=aHR0cHM6Ly9xaWl0YS11c2VyLWNvbnRlbnRzLmltZ2l4Lm5ldC9-dGV4dD9peGxpYj1yYi00LjAuMCZ3PTgzOCZoPTU4JnR4dD0lNDBvbW9jaGlfMDYwNCZ0eHQtY29sb3I9JTIzRkZGRkZGJnR4dC1mb250PUhpcmFnaW5vJTIwU2FucyUyMFc2JnR4dC1zaXplPTM2JnR4dC1wYWQ9MCZzPWFmMzEzZDA5ZDkzZTNiMjYzODIxOWVlYTk1NzI2N2Fl&blend-x=242&blend-y=480&blend-w=838&blend-h=46&blend-fit=crop&blend-crop=left%2Cbottom&blend-mode=normal&s=a345ec59d773d7f882648dfa308acff8" width="120" height="90" alt="「公共Wi-Fiは危険」ってよく聞くけど… どこがどう危ないの？物理から紐解くセキュリティ入門" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">「公共Wi-Fiは危険」ってよく聞くけど… どこがどう危ないの？物理から紐解くセキュリティ入門</h4>
+                <p class="card-source">Qiita</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://qiita.com/ShigemoriMasato/items/b254709391d2cbb1bbe6?utm_campaign=popular_items&utm_medium=feed&utm_source=popular_items" class="card">
+        <div class="card-content">
+            <img src="https://qiita-user-contents.imgix.net/https%3A%2F%2Fqiita-user-contents.imgix.net%2Fhttps%253A%252F%252Fcdn.qiita.com%252Fassets%252Fpublic%252Farticle-ogp-background-afbab5eb44e0b055cce1258705637a91.png%3Fixlib%3Drb-4.0.0%26w%3D1200%26blend64%3DaHR0cHM6Ly9xaWl0YS11c2VyLXByb2ZpbGUtaW1hZ2VzLmltZ2l4Lm5ldC9odHRwcyUzQSUyRiUyRnMzLWFwLW5vcnRoZWFzdC0xLmFtYXpvbmF3cy5jb20lMkZxaWl0YS1pbWFnZS1zdG9yZSUyRjAlMkYzNTIxNTczJTJGMTUxZWYzYTNiNGRiNDcwNTU1ODM1MDZlZjExODNiM2M4YzQyOGJhMSUyRnhfbGFyZ2UucG5nJTNGMTc1MTE0NzI1Nz9peGxpYj1yYi00LjAuMCZhcj0xJTNBMSZmaXQ9Y3JvcCZtYXNrPWVsbGlwc2UmZm09cG5nMzImcz1jOWM0MTA5Njc3MjNlMTVkODc1NGY2OWIxMDI2MThlNw%26blend-x%3D120%26blend-y%3D467%26blend-w%3D82%26blend-h%3D82%26blend-mode%3Dnormal%26s%3D90c04cd81ffbe8678870c7fd7b85f70f?ixlib=rb-4.0.0&w=1200&fm=jpg&mark64=aHR0cHM6Ly9xaWl0YS11c2VyLWNvbnRlbnRzLmltZ2l4Lm5ldC9-dGV4dD9peGxpYj1yYi00LjAuMCZ3PTk2MCZoPTMyNCZ0eHQ9JTVCJUU1JTg1JUE1JUU5JTk2JTgwJTVEJTIwUHl0aG9uJUUzJTgxJUE3dXYlRTMlODElQThQRVAlMjA3MjMlRTMlODIlOTIlRTQlQkQlQkYlRTMlODElODYlRTMlODElQTglRTklOTYlOEIlRTclOTklQkElRTQlQkQlOTMlRTklQTglOTMlRTMlODElOEMxMCVFNSU4MCU4RCVFNSU5MCU5MSVFNCVCOCU4QSVFMyU4MSU5OSVFMyU4MiU4QiVFNyU5MCU4NiVFNyU5NCVCMSZ0eHQtYWxpZ249bGVmdCUyQ3RvcCZ0eHQtY29sb3I9JTIzMUUyMTIxJnR4dC1mb250PUhpcmFnaW5vJTIwU2FucyUyMFc2JnR4dC1zaXplPTU2JnR4dC1wYWQ9MCZzPTcyMzhhOTQ1N2ZkNWExYWQwYmY3YzExODVhOTlhYjEw&mark-x=120&mark-y=112&blend64=aHR0cHM6Ly9xaWl0YS11c2VyLWNvbnRlbnRzLmltZ2l4Lm5ldC9-dGV4dD9peGxpYj1yYi00LjAuMCZ3PTgzOCZoPTU4JnR4dD0lNDBTaGlnZW1vcmlNYXNhdG8mdHh0LWNvbG9yPSUyMzFFMjEyMSZ0eHQtZm9udD1IaXJhZ2lubyUyMFNhbnMlMjBXNiZ0eHQtc2l6ZT0zNiZ0eHQtcGFkPTAmcz01NWYyMTRhNGU0YmFjYTk5NGNmOWVkZTUyYzI2YzM5Zg&blend-x=242&blend-y=480&blend-w=838&blend-h=46&blend-fit=crop&blend-crop=left%2Cbottom&blend-mode=normal&s=91cd96b75717d09b91b53993026f3258" width="120" height="90" alt="[入門] PythonでuvとPEP 723を使うと開発体験が10倍向上する理由" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">[入門] PythonでuvとPEP 723を使うと開発体験が10倍向上する理由</h4>
+                <p class="card-source">Qiita</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://qiita.com/Yametaro/items/0b241519dc6b416474c5?utm_campaign=popular_items&utm_medium=feed&utm_source=popular_items" class="card">
+        <div class="card-content">
+            <div class="card-text">
+                <h4 class="card-title">10歳娘「凡ミスの多い人ってプログラマーに向いてるよね」</h4>
+                <p class="card-source">Qiita</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://qiita.com/issy929/items/e02154bea72c4cff3106?utm_campaign=popular_items&utm_medium=feed&utm_source=popular_items" class="card">
+        <div class="card-content">
+            <img src="https://qiita-user-contents.imgix.net/https%3A%2F%2Fqiita-user-contents.imgix.net%2Fhttps%253A%252F%252Fcdn.qiita.com%252Fassets%252Fpublic%252Farticle-ogp-background-afbab5eb44e0b055cce1258705637a91.png%3Fixlib%3Drb-4.0.0%26w%3D1200%26blend64%3DaHR0cHM6Ly9xaWl0YS11c2VyLXByb2ZpbGUtaW1hZ2VzLmltZ2l4Lm5ldC9odHRwcyUzQSUyRiUyRmxoMy5nb29nbGV1c2VyY29udGVudC5jb20lMkZhJTJGQUNnOG9jTHhzREZaVnNZREJCNE5VSnJVMmhuQUJYYjlMTXFRMFJqOTdVbU1zdDRYNTVucUM1amwlM0RzOTYtYz9peGxpYj1yYi00LjAuMCZhcj0xJTNBMSZmaXQ9Y3JvcCZtYXNrPWVsbGlwc2UmZm09cG5nMzImcz1kOWUzMmFhOTQ4YTdmZTQ2MTVjZDk4NzA5YzAxYzdhOQ%26blend-x%3D120%26blend-y%3D467%26blend-w%3D82%26blend-h%3D82%26blend-mode%3Dnormal%26s%3Dd1927e5e364e169bf81a5a83d450d460?ixlib=rb-4.0.0&w=1200&fm=jpg&mark64=aHR0cHM6Ly9xaWl0YS11c2VyLWNvbnRlbnRzLmltZ2l4Lm5ldC9-dGV4dD9peGxpYj1yYi00LjAuMCZ3PTk2MCZoPTMyNCZ0eHQ9QVdTJTIwU3VtbWl0JTIwMjAyNSUyMENvbW11bml0eSUyMFN0YWdlJUU1JTg1JUE4JUUzJTgyJUJCJUUzJTgzJTgzJUUzJTgyJUI3JUUzJTgzJUE3JUUzJTgzJUIzJUVGJUJDJTg2JUU4JUIzJTg3JUU2JTk2JTk5JUUzJTgxJUJFJUUzJTgxJUE4JUUzJTgyJTgxJnR4dC1hbGlnbj1sZWZ0JTJDdG9wJnR4dC1jb2xvcj0lMjMxRTIxMjEmdHh0LWZvbnQ9SGlyYWdpbm8lMjBTYW5zJTIwVzYmdHh0LXNpemU9NTYmdHh0LXBhZD0wJnM9NzFiY2JmMDA2MWVmZDFlNzA3NGYzZDI0NjdkZGE3MmU&mark-x=120&mark-y=112&blend64=aHR0cHM6Ly9xaWl0YS11c2VyLWNvbnRlbnRzLmltZ2l4Lm5ldC9-dGV4dD9peGxpYj1yYi00LjAuMCZ3PTgzOCZoPTU4JnR4dD0lNDBpc3N5OTI5JnR4dC1jb2xvcj0lMjMxRTIxMjEmdHh0LWZvbnQ9SGlyYWdpbm8lMjBTYW5zJTIwVzYmdHh0LXNpemU9MzYmdHh0LXBhZD0wJnM9Mjg4Y2JlMzEzOTVkNGJmOTg2MDg5MjIyM2U4ZWQ4OTQ&blend-x=242&blend-y=480&blend-w=838&blend-h=46&blend-fit=crop&blend-crop=left%2Cbottom&blend-mode=normal&s=0de8e51f31eefa5e38d9f5a311525d63" width="120" height="90" alt="AWS Summit 2025 Community Stage全セッション＆資料まとめ" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">AWS Summit 2025 Community Stage全セッション＆資料まとめ</h4>
+                <p class="card-source">Qiita</p>
+            </div>
+        </div>
+    </a>
+    <hr>
+    <h2><img src="https://b.hatena.ne.jp/favicon.ico" width="16" height="16" alt="はてなブックマーク - IT（人気）"> はてなブックマーク - IT（人気）</h2>
+    <a href="https://zenn.dev/sesere/articles/0420ecec9526dc" class="card">
+        <div class="card-content">
+            <img src="https://res.cloudinary.com/zenn/image/upload/s--4ISgUHFQ--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:Claude%2520Code%25E3%2581%25AE%25E3%2580%258C%25E3%2581%2599%25E3%2581%2590%25E3%2583%25AB%25E3%2583%25BC%25E3%2583%25AB%25E5%25BF%2598%25E3%2582%258C%25E3%2582%258B%25E5%2595%258F%25E9%25A1%258C%25E3%2580%258D%25E3%2582%2592%25E8%25A7%25A3%25E6%25B1%25BA%25E3%2581%2599%25E3%2582%258B%25E8%25B6%2585%25E5%258A%25B9%25E6%259E%259C%25E7%259A%2584%25E3%2581%25AA%25E6%2596%25B9%25E6%25B3%2595%25E3%2582%2592%25E8%25A6%258B%25E3%2581%25A4%25E3%2581%2591%25E3%2581%259F%25E6%25B0%2597%25E3%2581%258C%25E3%2581%2599%25E3%2582%258B%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_37:sesere%2Cx_203%2Cy_121/g_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzg4NjY3ZDcwMjMuanBlZw==%2Cr_max%2Cw_90%2Cx_87%2Cy_95/v1627283836/default/og-base-w1200-v2.png" width="120" height="90" alt="Claude Codeの「すぐルール忘れる問題」を解決する超効果的な方法を見つけた気がする" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">Claude Codeの「すぐルール忘れる問題」を解決する超効果的な方法を見つけた気がする</h4>
+                <p class="card-source">はてなブックマーク - IT（人気）</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://www.nikkei.com/article/DGXZQOUC13BCW0T10C25A6000000/" class="card">
+        <div class="card-content">
+            <img src="https://article-image-ix.nikkei.com/https%3A%2F%2Fimgix-proxy.n8s.jp%2FDSXZQO6591894026062025000000-1.jpg?auto=format&bg=FFFF&crop=focalpoint&fit=crop&h=630&upscale=false&w=1200&s=7319c6d7a7bfc5ea96ad37e8c15cda98" width="120" height="90" alt="論文内に秘密の命令文、AIに「高評価せよ」　日韓米など有力14大学で - 日本経済新聞" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">論文内に秘密の命令文、AIに「高評価せよ」　日韓米など有力14大学で - 日本経済新聞</h4>
+                <p class="card-source">はてなブックマーク - IT（人気）</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://togetter.com/li/2569663" class="card">
+        <div class="card-content">
+            <img src="https://s.tgstc.com/ogp3/2ec1d5c36447249ce11fa8f9c568fdc6-1200x630.jpeg" width="120" height="90" alt="「アホのファイル転送(PC2台をLANケーブルで直結)」→実はデータ移行ではワイヤレート近くが出るので便利「仕事でoutlookのファイルサイズが異常に大きい客が居た時に有用」" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">「アホのファイル転送(PC2台をLANケーブルで直結)」→実はデータ移行ではワイヤレート近くが出るので便利「仕事でoutlookのファイルサイズが異常に大きい客が居た時に有用」</h4>
+                <p class="card-source">はてなブックマーク - IT（人気）</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://www.m3tech.blog/entry/2025/06/29/110000" class="card">
+        <div class="card-content">
+            <img src="https://cdn.image.st-hatena.com/image/scale/ac19f8b37b13e1f29fe12c92d6ae177534e24840/backend=imagemagick;version=1;width=1300/https%3A%2F%2Fcdn-ak.f.st-hatena.com%2Fimages%2Ffotolife%2Fm%2Fm3tech%2F20250629%2F20250629110005.png" width="120" height="90" alt="「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ</h4>
+                <p class="card-source">はてなブックマーク - IT（人気）</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://togetter.com/li/2569535" class="card">
+        <div class="card-content">
+            <img src="https://s.tgstc.com/ogp3/100d7c98cff7b156adf87c400d354c7c-1200x630.jpeg" width="120" height="90" alt="授業参観に行ったらネットリテラシー講座がセキュリティソフトの営業会場になっていた話" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">授業参観に行ったらネットリテラシー講座がセキュリティソフトの営業会場になっていた話</h4>
+                <p class="card-source">はてなブックマーク - IT（人気）</p>
+            </div>
+        </div>
+    </a>
+    <hr>
+    <h2><img src="https://b.hatena.ne.jp/favicon.ico" width="16" height="16" alt="はてなブックマーク - IT（新着）"> はてなブックマーク - IT（新着）</h2>
+    <a href="https://gigazine.net/news/20250630-scale-ai-google-gemini-spam-problem/" class="card">
+        <div class="card-content">
+            <img src="https://i.gzn.jp/img/2025/06/30/scale-ai-google-gemini-spam-problem/00_m.jpg" width="120" height="90" alt="GoogleのAI「Gemini」をScale AIがトレーニングしようとしたら未審査のフリーランサーによるあまりにも粗悪な仕事が横行していたことが判明" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">GoogleのAI「Gemini」をScale AIがトレーニングしようとしたら未審査のフリーランサーによるあまりにも粗悪な仕事が横行していたことが判明</h4>
+                <p class="card-source">はてなブックマーク - IT（新着）</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://internet.watch.impress.co.jp/docs/column/shimizu/2024741.html" class="card">
+        <div class="card-content">
+            <img src="https://internet.watch.impress.co.jp/img/iw/list/2024/741/001.png" width="120" height="90" alt="Win 11対応PCを家族や友人に譲るなら、「Sysprep」で“不要なアプリを削除した初期化環境”を作るべし！【イニシャルB】" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">Win 11対応PCを家族や友人に譲るなら、「Sysprep」で“不要なアプリを削除した初期化環境”を作るべし！【イニシャルB】</h4>
+                <p class="card-source">はてなブックマーク - IT（新着）</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://forest.watch.impress.co.jp/docs/news/2026720.html" class="card">
+        <div class="card-content">
+            <img src="https://forest.watch.impress.co.jp/img/wf/list/2026/720/image1.png" width="120" height="90" alt="「Windows 11 バージョン 25H2」のテストが開始、正式リリースは2025年後半／次期機能更新プログラム、「バージョン 24H2」とはコード共通で「eKB」による切り替え" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">「Windows 11 バージョン 25H2」のテストが開始、正式リリースは2025年後半／次期機能更新プログラム、「バージョン 24H2」とはコード共通で「eKB」による切り替え</h4>
+                <p class="card-source">はてなブックマーク - IT（新着）</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://note.com/genkaijokyo/n/nfb96a13e084f" class="card">
+        <div class="card-content">
+            <img src="https://assets.st-note.com/production/uploads/images/198866846/rectangle_large_type_2_cbfbd791e5f77ae712958616d5539f15.png?fit=bounds&quality=85&width=1280" width="120" height="90" alt="なぜ今、研究者はGeminiを選ぶべきか？他のAIとの比較で見る10のメリット｜genkAIjokyo|ChatGPT/Claudeで論文作成と科研費申請" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">なぜ今、研究者はGeminiを選ぶべきか？他のAIとの比較で見る10のメリット｜genkAIjokyo|ChatGPT/Claudeで論文作成と科研費申請</h4>
+                <p class="card-source">はてなブックマーク - IT（新着）</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://www.publickey1.jp/blog/25/visual_studio_codeaigithub_copilot_chat.html" class="card">
+        <div class="card-content">
+            <img src="https://www.publickey1.jp/2025/github-copilot-chat-oss-la01.jpg" width="120" height="90" alt="Visual Studio CodeのAIエディタ化が前進、GitHub Copilot Chatがオープンソースで公開。現在プレリリース版" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">Visual Studio CodeのAIエディタ化が前進、GitHub Copilot Chatがオープンソースで公開。現在プレリリース版</h4>
+                <p class="card-source">はてなブックマーク - IT（新着）</p>
+            </div>
+        </div>
+    </a>
+    <hr>
+    <h2><img src="https://dev.classmethod.jp/favicon.ico" width="16" height="16" alt="DevelopersIO"> DevelopersIO</h2>
+    <a href="https://dev.classmethod.jp/articles/creating-web-access-report-and-uploading-s3-claude-code/" class="card">
+        <div class="card-content">
+            <img src="https://dev.classmethod.jp/img/burger.svg" width="120" height="90" alt="Claude Code を活用！Webアクセス解析レポートの作成と S3 公開を自動化してみた" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">Claude Code を活用！Webアクセス解析レポートの作成と S3 公開を自動化してみた</h4>
+                <p class="card-source">DevelopersIO</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://dev.classmethod.jp/articles/waf-protection-pack/" class="card">
+        <div class="card-content">
+            <img src="https://dev.classmethod.jp/img/burger.svg" width="120" height="90" alt="AWS WAF 新コンソールの「保護パック」を新規作成する時に、何をどう選択したら良いのか調べてみた" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">AWS WAF 新コンソールの「保護パック」を新規作成する時に、何をどう選択したら良いのか調べてみた</h4>
+                <p class="card-source">DevelopersIO</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://dev.classmethod.jp/articles/amazon-connect-customer-profiles-profile-list/" class="card">
+        <div class="card-content">
+            <img src="https://dev.classmethod.jp/img/burger.svg" width="120" height="90" alt="Amazon Connect Customer Profilesに登録された全顧客の一覧を取得する方法" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">Amazon Connect Customer Profilesに登録された全顧客の一覧を取得する方法</h4>
+                <p class="card-source">DevelopersIO</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://dev.classmethod.jp/articles/ga-accelerate-troubleshooting-amazon-cloudwatch-investigations/" class="card">
+        <div class="card-content">
+            <img src="https://images.ctfassets.net/ct0aopd36mqt/6mDy5OHyuWO0BYkCTdEVsb/fb81a40db3365780c00e8d5c8927d5c0/eyecatch_awssummitjapan2025_nomal_1200x630.jpg" width="120" height="90" alt="[アップデート] Amazon CloudWatch の運用調査機能が一般提供を開始したため、概要をまとめてみた" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">[アップデート] Amazon CloudWatch の運用調査機能が一般提供を開始したため、概要をまとめてみた</h4>
+                <p class="card-source">DevelopersIO</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://dev.classmethod.jp/articles/amazon-q-cli-mini-factrio/" class="card">
+        <div class="card-content">
+            <img src="https://devio2024-media.developers.io/image/upload/v1751206681/user-gen-eyecatch/tiqexbonjlyzahotqxps.png" width="120" height="90" alt="Amazon Q CLIで鉄鉱石採掘体験ゲームを作ってみた #AmazonQCLI" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">Amazon Q CLIで鉄鉱石採掘体験ゲームを作ってみた #AmazonQCLI</h4>
+                <p class="card-source">DevelopersIO</p>
+            </div>
+        </div>
+    </a>
+    <hr>
+    <h2><img src="https://gihyo.jp/favicon.ico" width="16" height="16" alt="gihyo.jp"> gihyo.jp</h2>
+    <a href="https://gihyo.jp/article/2025/06/claude-desktop-extensions?utm_source=feed" class="card">
+        <div class="card-content">
+            <img src="https://gihyo.jp/assets/images/ICON/2025/2543_claude-desktop-extention.png" width="120" height="90" alt="Anthropic、ワンクリックでローカルMCPサーバーをインストールできる「Desktop Extensions」をリリース" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">Anthropic、ワンクリックでローカルMCPサーバーをインストールできる「Desktop Extensions」をリリース</h4>
+                <p class="card-source">gihyo.jp</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://gihyo.jp/article/2025/06/color-me-shop-day-2025?utm_source=feed" class="card">
+        <div class="card-content">
+            <img src="https://gihyo.jp/assets/images/ICON/2025/2544_cmsd2025.png" width="120" height="90" alt="GMOペパボ、ECサイト運営者を対象にした参加費無料のオンライントークイベント「COLOR ME SHOP DAY 2025」を7月24日に開催" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">GMOペパボ、ECサイト運営者を対象にした参加費無料のオンライントークイベント「COLOR ME SHOP DAY 2025」を7月24日に開催</h4>
+                <p class="card-source">gihyo.jp</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://gihyo.jp/article/2025/06/google-gemma-3n?utm_source=feed" class="card">
+        <div class="card-content">
+            <img src="https://gihyo.jp/assets/images/ICON/2025/2542_gemma-3n.png" width="120" height="90" alt="Google、Gemma 3nをリリース ―エッジデバイスでの動作効率が大幅アップ、フレキシブルなマルチモーダルモデル" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">Google、Gemma 3nをリリース ―エッジデバイスでの動作効率が大幅アップ、フレキシブルなマルチモーダルモデル</h4>
+                <p class="card-source">gihyo.jp</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://gihyo.jp/admin/clip/01/ubuntu-topics/202506/27?utm_source=feed" class="card">
+        <div class="card-content">
+            <img src="https://gihyo.jp/assets/images/ICON/2022/1903_ubuntu-topics.png" width="120" height="90" alt="MediaTek Genio向けのUbuntu Core、Ubuntu 25.10（questing）の開発; 新しいゴミ箱アイコンとServer Seedの見直し" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">MediaTek Genio向けのUbuntu Core、Ubuntu 25.10（questing）の開発; 新しいゴミ箱アイコンとServer Seedの見直し</h4>
+                <p class="card-source">gihyo.jp</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://gihyo.jp/article/2025/06/fastly-tyler-mcmullen?utm_source=feed" class="card">
+        <div class="card-content">
+            <img src="https://gihyo.jp/assets/images/ICON/2025/2541_fastly.png" width="120" height="90" alt="最大の差別化要因はWebAssemblyの採用 ―― Fastly共同創業者Tyler McMullen氏に聞く次世代CDNの最前線" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">最大の差別化要因はWebAssemblyの採用 ―― Fastly共同創業者Tyler McMullen氏に聞く次世代CDNの最前線</h4>
+                <p class="card-source">gihyo.jp</p>
+            </div>
+        </div>
+    </a>
+    <hr>
+    <h2><img src="https://www.publickey1.jp/favicon.ico" width="16" height="16" alt="Publickey"> Publickey</h2>
+    <a href="https://www.publickey1.jp/blog/25/android_studiogeminiai.html" class="card">
+        <div class="card-content">
+            <img src="https://www.publickey1.jp/2025/android-studio-gemini-agentmode-la04.png" width="120" height="90" alt="Android StudioでGeminiのエージェントモードが利用可能に。「ダークモードを追加して」などの指示でAIが自律コーディング" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">Android StudioでGeminiのエージェントモードが利用可能に。「ダークモードを追加して」などの指示でAIが自律コーディング</h4>
+                <p class="card-source">Publickey</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://www.publickey1.jp/blog/25/awsgoogleaiagent2agentlinux_foundation.html" class="card">
+        <div class="card-content">
+            <img src="https://www.publickey1.jp/2025/GuI94osXIAAjo3T.jpg" width="120" height="90" alt="AWS、Google、マイクロソフトらがAIエージェント連携のため「Agent2Agentプロジェクト」設立。Linux Foundation傘下で" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">AWS、Google、マイクロソフトらがAIエージェント連携のため「Agent2Agentプロジェクト」設立。Linux Foundation傘下で</h4>
+                <p class="card-source">Publickey</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://www.publickey1.jp/blog/25/cloudflareworkers_kvgoogle_cloudgoogle_cloud.html" class="card">
+        <div class="card-content">
+            <img src="https://www.publickey1.jp/2025/cloudflare-failure-2025june.png" width="120" height="90" alt="Cloudflareが重大なサービス障害の原因を説明。実はWorkers KVがGoogle Cloudに依存しており、Google Cloudの障害が原因だったと" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">Cloudflareが重大なサービス障害の原因を説明。実はWorkers KVがGoogle Cloudに依存しており、Google Cloudの障害が原因だったと</h4>
+                <p class="card-source">Publickey</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://www.publickey1.jp/blog/25/pcpcwindows_365_reserve.html" class="card">
+        <div class="card-content">
+            <img src="https://www.publickey1.jp/2025/ms365reserve-prev01.png" width="120" height="90" alt="マイクロソフト、PCの紛失や故障などのとき一時的に同構成のクラウドPCが使える「Windows 365 Reserve」プレビュー公開" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">マイクロソフト、PCの紛失や故障などのとき一時的に同構成のクラウドPCが使える「Windows 365 Reserve」プレビュー公開</h4>
+                <p class="card-source">Publickey</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://www.publickey1.jp/blog/25/cve_foundation.html" class="card">
+        <div class="card-content">
+            <img src="https://www.publickey1.jp/2025/cve-foundation-board01.png" width="120" height="90" alt="CVE Foundationが取締役会と今後の計画を明らかに。安定性のために複数の収入源による財務基盤を確立など" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">CVE Foundationが取締役会と今後の計画を明らかに。安定性のために複数の収入源による財務基盤を確立など</h4>
+                <p class="card-source">Publickey</p>
+            </div>
+        </div>
+    </a>
+    <hr>
+    <h2><img src="https://codezine.jp/favicon.ico" width="16" height="16" alt="CodeZine"> CodeZine</h2>
+    <a href="http://codezine.jp/article/detail/21801" class="card">
+        <div class="card-content">
+            <img src="https://codezine.jp/static/images/article/21801/21801_ogp.png" width="120" height="90" alt="ITエンジニア注目トレンドを総まとめ！週間ニュースランキングTOP10【6/20～6/26】" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">ITエンジニア注目トレンドを総まとめ！週間ニュースランキングTOP10【6/20～6/26】</h4>
+                <p class="card-source">CodeZine</p>
+            </div>
+        </div>
+    </a>
+    <a href="http://codezine.jp/article/detail/21798" class="card">
+        <div class="card-content">
+            <img src="https://codezine.jp/static/images/article/21798/21798_ogp.png" width="120" height="90" alt="メシウス、PDFファイル内の表をExcelで出力できるドキュメントAPIライブラリの最新版をリリース" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">メシウス、PDFファイル内の表をExcelで出力できるドキュメントAPIライブラリの最新版をリリース</h4>
+                <p class="card-source">CodeZine</p>
+            </div>
+        </div>
+    </a>
+    <a href="http://codezine.jp/article/detail/21802" class="card">
+        <div class="card-content">
+            <img src="https://codezine.jp/static/images/article/21802/1200ogpbbb.png" width="120" height="90" alt="Linux Foundation、「Agent2Agentプロジェクト」の設立を発表" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">Linux Foundation、「Agent2Agentプロジェクト」の設立を発表</h4>
+                <p class="card-source">CodeZine</p>
+            </div>
+        </div>
+    </a>
+    <a href="http://codezine.jp/article/detail/21803" class="card">
+        <div class="card-content">
+            <img src="https://codezine.jp/static/images/article/21803/1200and.png" width="120" height="90" alt="Google、Android StudioのGeminiにエージェント機能を追加" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">Google、Android StudioのGeminiにエージェント機能を追加</h4>
+                <p class="card-source">CodeZine</p>
+            </div>
+        </div>
+    </a>
+    <a href="http://codezine.jp/article/detail/21433" class="card">
+        <div class="card-content">
+            <img src="https://codezine.jp/static/images/article/21433/21433_ogp.jpg" width="120" height="90" alt="バックエンドの知識が活きるReact入門──オブジェクト指向で学ぶフロントエンド" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">バックエンドの知識が活きるReact入門──オブジェクト指向で学ぶフロントエンド</h4>
+                <p class="card-source">CodeZine</p>
+            </div>
+        </div>
+    </a>
+    <hr>
+    <h2><img src="https://www.infoq.com/favicon.ico" width="16" height="16" alt="InfoQ Japan"> InfoQ Japan</h2>
+    <a href="https://www.infoq.com/jp/news/2025/06/amazon-q-cli-claude-code/?utm_campaign=infoq_content&utm_source=infoq&utm_medium=feed&utm_term=global" class="card">
+        <div class="card-content">
+            <img src="https://cdn.infoq.com/statics_s2_20250605075544/styles/static/images/logo/logo-big.jpg" width="120" height="90" alt="Amazon QとClaude Codeが開発者CLIをAIで制御可能に" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">Amazon QとClaude Codeが開発者CLIをAIで制御可能に</h4>
+                <p class="card-source">InfoQ Japan</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://www.infoq.com/jp/news/2025/06/cisco-jarvis-ai-assistant/?utm_campaign=infoq_content&utm_source=infoq&utm_medium=feed&utm_term=global" class="card">
+        <div class="card-content">
+            <img src="https://cdn.infoq.com/statics_s1_20250605075448/styles/static/images/logo/logo-big.jpg" width="120" height="90" alt="CiscoがJARVISを発表：プラットフォームエンジニアリングチームのためのAIアシスタント" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">CiscoがJARVISを発表：プラットフォームエンジニアリングチームのためのAIアシスタント</h4>
+                <p class="card-source">InfoQ Japan</p>
+            </div>
+        </div>
+    </a>
+    <hr>
+    <h2><img src="https://connpass.com/favicon.ico" width="16" height="16" alt="connpass - イベント"> connpass - イベント</h2>
+    <a href="https://findy.connpass.com/event/360678/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom" class="card">
+        <div class="card-content">
+            <img src="https://media.connpass.com/thumbs/f2/ce/f2ce5aba9809e2c50153e63dba0dfb9d.png" width="120" height="90" alt="実践！バックエンドTypeScript〜現場から学ぶtsの可能性〜" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">実践！バックエンドTypeScript〜現場から学ぶtsの可能性〜</h4>
+                <p class="card-source">connpass - イベント</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://jawsug-kanazawa.connpass.com/event/360910/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom" class="card">
+        <div class="card-content">
+            <img src="https://media.connpass.com/thumbs/04/c3/04c3e3ad4650a3bf0649f95d1031fcab.png" width="120" height="90" alt="JAWS-UG金沢 #105 AWS Summit 振り返りLT会" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">JAWS-UG金沢 #105 AWS Summit 振り返りLT会</h4>
+                <p class="card-source">connpass - イベント</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://jaws-ug.connpass.com/event/360939/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom" class="card">
+        <div class="card-content">
+            <img src="https://media.connpass.com/thumbs/73/46/73464bb319ae36733f415678f692f595.png" width="120" height="90" alt="#84 JAWS-UG主催 週刊AWSキャッチアップ （2025/6/16&23週）" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">#84 JAWS-UG主催 週刊AWSキャッチアップ （2025/6/16&23週）</h4>
+                <p class="card-source">connpass - イベント</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://math-coding.connpass.com/event/360940/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom" class="card">
+        <div class="card-content">
+            <img src="https://media.connpass.com/thumbs/f5/1d/f51dee54c81cd2ddf9dd7485614d0589.png" width="120" height="90" alt="早朝オンライン[Math & Coding] 多様体の基礎 #97" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">早朝オンライン[Math & Coding] 多様体の基礎 #97</h4>
+                <p class="card-source">connpass - イベント</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://openforce.connpass.com/event/360937/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom" class="card">
+        <div class="card-content">
+            <img src="https://media.connpass.com/thumbs/25/76/2576e2b244bbaf8b6f26399ed73ce154.png" width="120" height="90" alt="オープンハードカンファレンスミーティング" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">オープンハードカンファレンスミーティング</h4>
+                <p class="card-source">connpass - イベント</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://xlsoftdevops.connpass.com/event/360772/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom" class="card">
+        <div class="card-content">
+            <img src="https://media.connpass.com/thumbs/90/ae/90ae5f7d9430363349e72618ec3fce46.png" width="120" height="90" alt="現場が変わる！Smartsheet でタスクの定型業務の自動化と可視化" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">現場が変わる！Smartsheet でタスクの定型業務の自動化と可視化</h4>
+                <p class="card-source">connpass - イベント</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://ssmjp.connpass.com/event/358686/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom" class="card">
+        <div class="card-content">
+            <img src="https://media.connpass.com/thumbs/c9/a6/c9a64b9abad46d068a1a864565f58610.png" width="120" height="90" alt="ssmonline #49" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">ssmonline #49</h4>
+                <p class="card-source">connpass - イベント</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://engineercafe.connpass.com/event/360029/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom" class="card">
+        <div class="card-content">
+            <img src="https://media.connpass.com/thumbs/1f/8f/1f8f92f821d99d4b6cc1f337fb6516e6.png" width="120" height="90" alt="ハードウェア技術誌を読もう：トランジスタ技術最新号よみあわせ解説会(2025年9月号)" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">ハードウェア技術誌を読もう：トランジスタ技術最新号よみあわせ解説会(2025年9月号)</h4>
+                <p class="card-source">connpass - イベント</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://engineercafe.connpass.com/event/360005/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom" class="card">
+        <div class="card-content">
+            <img src="https://media.connpass.com/thumbs/f4/bd/f4bdabd4168c9aa0db50e4d1cb70f0c0.png" width="120" height="90" alt="ハードウェア技術誌を読もう：トランジスタ技術最新号よみあわせ解説会(2025年8月号)" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">ハードウェア技術誌を読もう：トランジスタ技術最新号よみあわせ解説会(2025年8月号)</h4>
+                <p class="card-source">connpass - イベント</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://machine-learning15minutes.connpass.com/event/360928/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom" class="card">
+        <div class="card-content">
+            <img src="https://media.connpass.com/thumbs/27/ae/27ae5033b59f8941ba33d899367bcb16.png" width="120" height="90" alt="第103回 Machine Learning 15minutes! Hybrid" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">第103回 Machine Learning 15minutes! Hybrid</h4>
+                <p class="card-source">connpass - イベント</p>
+            </div>
+        </div>
+    </a>
+    <hr>
+    <h2><img src="https://techplay.jp/favicon.ico" width="16" height="16" alt="TECH PLAY - イベント"> TECH PLAY - イベント</h2>
+    <a href="https://techplay.jp/event/983039" class="card">
+        <div class="card-content">
+            <img src="https://s3.techplay.jp/tp-images/event/5d526657a758d1783420fd3511f07b1d94718568.png?w=1200" width="120" height="90" alt="実践！バックエンドTypeScript〜現場から学ぶtsの可能性〜" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">実践！バックエンドTypeScript〜現場から学ぶtsの可能性〜</h4>
+                <p class="card-source">TECH PLAY - イベント</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://techplay.jp/event/983083" class="card">
+        <div class="card-content">
+            <img src="https://s3.techplay.jp/tp-images/event/fa4d36aaa4e83c4fa9d85f55787b198aabb5a1b2.png?w=1200" width="120" height="90" alt="現場が変わる！Smartsheet でタスクの定型業務の自動化と可視化" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">現場が変わる！Smartsheet でタスクの定型業務の自動化と可視化</h4>
+                <p class="card-source">TECH PLAY - イベント</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://techplay.jp/event/983108" class="card">
+        <div class="card-content">
+            <img src="https://s3.techplay.jp/tp-images/event/1449d2b543927a9aae2c0a7e1dd7f0032082105a.png?w=1200" width="120" height="90" alt="SnowVillage Unconference #6　– 初心者大歓迎！聞き専/飛入登壇, ご自由なスタイルで！" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">SnowVillage Unconference #6　– 初心者大歓迎！聞き専/飛入登壇, ご自由なスタイルで！</h4>
+                <p class="card-source">TECH PLAY - イベント</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://techplay.jp/event/983102" class="card">
+        <div class="card-content">
+            <img src="https://s3.techplay.jp/tp-images/event/404a4f0aa91f14f7c6660956c7e6343fd6be7ead.png?w=1200" width="120" height="90" alt="7/11(金)開催　初心者でもわかる基本用語解説セミナー" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">7/11(金)開催　初心者でもわかる基本用語解説セミナー</h4>
+                <p class="card-source">TECH PLAY - イベント</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://techplay.jp/event/983101" class="card">
+        <div class="card-content">
+            <img src="https://s3.techplay.jp/tp-images/event/35db422932a6fddaccb541d0592935ba66c1f24b.jpg?w=1200" width="120" height="90" alt="Instagram×LINEで売上130%UP ～フォロワーの価値を最大化させる3つのポイント～" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">Instagram×LINEで売上130%UP ～フォロワーの価値を最大化させる3つのポイント～</h4>
+                <p class="card-source">TECH PLAY - イベント</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://techplay.jp/event/983084" class="card">
+        <div class="card-content">
+            <img src="https://s3.techplay.jp/tp-images/event/0641b40badb56b5e1cd99b403fbeb77f3e5d8a7a.png?w=1200" width="120" height="90" alt="07/05 Power BI 実演ライブ #9｜米の消費/需給データ" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">07/05 Power BI 実演ライブ #9｜米の消費/需給データ</h4>
+                <p class="card-source">TECH PLAY - イベント</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://techplay.jp/event/983055" class="card">
+        <div class="card-content">
+            <img src="https://s3.techplay.jp/tp-images/event/863b8da7c47eb716a8064060f8896625204da1cb.jpg?w=1200" width="120" height="90" alt="【定員5人】GA4 × サーチコンソール × AI分析 × LLMO(AI検索最適化)準備 × 投資対効果も解説！可視化と自走を両立 ― これから始める「分析体制構築」不透明な未来に強固な仕組みを【別日開催あり】" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">【定員5人】GA4 × サーチコンソール × AI分析 × LLMO(AI検索最適化)準備 × 投資対効果も解説！可視化と自走を両立 ― これから始める「分析体制構築」不透明な未来に強固な仕組みを【別日開催あり】</h4>
+                <p class="card-source">TECH PLAY - イベント</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://techplay.jp/event/982480" class="card">
+        <div class="card-content">
+            <img src="https://s3.techplay.jp/tp-images/event/d79ad448e2a5c39a4f342907c811d9ff5a6b4b3c.jpg?w=1200" width="120" height="90" alt="〜Tableau tuneup Vol.15 ~初心者相談室×Tabもく会~" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">〜Tableau tuneup Vol.15 ~初心者相談室×Tabもく会~</h4>
+                <p class="card-source">TECH PLAY - イベント</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://techplay.jp/event/983092" class="card">
+        <div class="card-content">
+            <img src="https://s3.techplay.jp/tp-images/event/56a9884b106b1c3f834e32750d3dc68d2d7232a9.png?w=1200" width="120" height="90" alt="ネットワークハンズオン（CCNA実習、AWS接続・L3スイッチ・ファイアウォール実習）" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">ネットワークハンズオン（CCNA実習、AWS接続・L3スイッチ・ファイアウォール実習）</h4>
+                <p class="card-source">TECH PLAY - イベント</p>
+            </div>
+        </div>
+    </a>
+    <a href="https://techplay.jp/event/982852" class="card">
+        <div class="card-content">
+            <img src="https://s3.techplay.jp/tp-images/event/bcff1c5e9b0f1b7bfdc2d99bb6e6f1f773195416.png?w=1200" width="120" height="90" alt="AWS Discovery Day 2025 in Winスクール" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">AWS Discovery Day 2025 in Winスクール</h4>
+                <p class="card-source">TECH PLAY - イベント</p>
+            </div>
+        </div>
+    </a>
+    <hr>
+    <h2><img src="https://www.oreilly.co.jp/favicon.ico" width="16" height="16" alt="O'Reilly Japan - 近刊"> O'Reilly Japan - 近刊</h2>
+    <a href="http://www.oreilly.co.jp/books/9784814401093/?utm_source=feed&utm_mediun=referral&utm_content=new_book" class="card">
+        <div class="card-content">
+            <img src="https://www.oreilly.co.jp/books/images/picture_large978-4-8144-0109-3.jpeg" width="120" height="90" alt="Effective TypeScript 第2版" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">Effective TypeScript 第2版</h4>
+                <p class="card-source">O'Reilly Japan - 近刊</p>
+            </div>
+        </div>
+    </a>
+    <a href="http://www.oreilly.co.jp/books/9784814401130/?utm_source=feed&utm_mediun=referral&utm_content=new_book" class="card">
+        <div class="card-content">
+            <img src="https://www.oreilly.co.jp/books/images/picture_large978-4-8144-0113-0.jpeg" width="120" height="90" alt="LLMのプロンプトエンジニアリング" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">LLMのプロンプトエンジニアリング</h4>
+                <p class="card-source">O'Reilly Japan - 近刊</p>
+            </div>
+        </div>
+    </a>
+    <a href="http://www.oreilly.co.jp/books/9784814400997/?utm_source=feed&utm_mediun=referral&utm_content=new_book" class="card">
+        <div class="card-content">
+            <img src="https://www.oreilly.co.jp/books/images/picture_large978-4-8144-0099-7.jpeg" width="120" height="90" alt="micro:bitではじめるAI工作" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">micro:bitではじめるAI工作</h4>
+                <p class="card-source">O'Reilly Japan - 近刊</p>
+            </div>
+        </div>
+    </a>
+    <a href="http://www.oreilly.co.jp/books/9784814401222/?utm_source=feed&utm_mediun=referral&utm_content=new_book" class="card">
+        <div class="card-content">
+            <img src="https://www.oreilly.co.jp/books/images/picture_large978-4-8144-0122-2.jpeg" width="120" height="90" alt="PythonによるWebスクレイピング 第3版" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">PythonによるWebスクレイピング 第3版</h4>
+                <p class="card-source">O'Reilly Japan - 近刊</p>
+            </div>
+        </div>
+    </a>
+    <a href="http://www.oreilly.co.jp/books/9784814401185/?utm_source=feed&utm_mediun=referral&utm_content=new_book" class="card">
+        <div class="card-content">
+            <img src="https://www.oreilly.co.jp/books/images/picture_large978-4-8144-0118-5.jpeg" width="120" height="90" alt="Async Rust" class="card-image">
+            <div class="card-text">
+                <h4 class="card-title">Async Rust</h4>
+                <p class="card-source">O'Reilly Japan - 近刊</p>
+            </div>
+        </div>
+    </a>
+    <hr>
+
+    <div class="footer">
+        <p>🚀 運営者: <a href="https://x.com/unsoluble_sugar" target="_blank" rel="noopener">@unsoluble_sugar</a> | 
+        📁 <a href="https://github.com/unsolublesugar/daily-tech-news" target="_blank" rel="noopener">GitHub Repository</a></p>
+    </div>
+</body>
+</html>

--- a/archives/2025/06/2025-06-30.md
+++ b/archives/2025/06/2025-06-30.md
@@ -1,6 +1,6 @@
 # 今日のテックニュース (2025-06-30)
 
-📚 [過去のニュースを見る](archives/index.md) | 🎨 [カード表示版を見る](https://unsolublesugar.github.io/daily-tech-news/)
+📚 [過去のニュースを見る](../../index.md) | 🎨 [カード表示版を見る](https://unsolublesugar.github.io/daily-tech-news/) | 📡 [RSSフィードを購読](https://unsolublesugar.github.io/daily-tech-news/rss.xml)
 
 日本の主要な技術系メディアの最新人気エントリーをお届けします。
 
@@ -24,11 +24,11 @@ https://unsolublesugar.github.io/daily-tech-news/
 ---
 ## <img src="https://zenn.dev/favicon.ico" width="16" height="16" alt="Zenn"> Zenn
 
-- [Claude Codeの「すぐルール忘れる問題」を解決する超効果的な方法を見つけた気がする](https://zenn.dev/sesere/articles/0420ecec9526dc)
-- [全人類、いますぐ Discord Webhook を使いこなそう](https://zenn.dev/oliver/articles/discord-webhook-guide)
 - [【初心者向け】各種ツールで学ぶin silicoタンパク質デザイン 〜新規デザインから物性評価まで~](https://zenn.dev/labcode/books/71b01f2557419e)
-- [Claude Code x Gemini CLI x OpenAI o3 x 人間による、四位一体開発術](https://zenn.dev/tksfjt1024/articles/ec2b985fc32c93)
 - [【Web Bluetooth API】Joy-Con 2 をプレゼンリモコンにする](https://zenn.dev/mascii/articles/joy-con-2-web-bluetooth-api)
+- [Gemini CLIをソース解析して発見したコーギーの出現方法](https://zenn.dev/oikon/articles/c8a887f00dd219)
+- [AIエージェントでバグバウンティ！ Cline × Claude Code × GPT-o3 で $2,000 を獲得した話](https://zenn.dev/grandchildrice/articles/499e22b0e9e4c8)
+- [初めてのTTSモデルをずんだもんのデータで作ってみた with LLaSA](https://zenn.dev/aratako_lm/articles/7e0b0b6e51baa6)
 
 
 ---
@@ -44,27 +44,27 @@ https://unsolublesugar.github.io/daily-tech-news/
 ---
 ## <img src="https://b.hatena.ne.jp/favicon.ico" width="16" height="16" alt="はてなブックマーク - IT（人気）"> はてなブックマーク - IT（人気）
 
-- [「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ](https://www.m3tech.blog/entry/2025/06/29/110000)
+- [Claude Codeの「すぐルール忘れる問題」を解決する超効果的な方法を見つけた気がする](https://zenn.dev/sesere/articles/0420ecec9526dc)
 - [論文内に秘密の命令文、AIに「高評価せよ」　日韓米など有力14大学で - 日本経済新聞](https://www.nikkei.com/article/DGXZQOUC13BCW0T10C25A6000000/)
 - [「アホのファイル転送(PC2台をLANケーブルで直結)」→実はデータ移行ではワイヤレート近くが出るので便利「仕事でoutlookのファイルサイズが異常に大きい客が居た時に有用」](https://togetter.com/li/2569663)
+- [「先週何したっけ？」をゼロに：Obsidian + Claude Codeを業務アシスタントに - エムスリーテックブログ](https://www.m3tech.blog/entry/2025/06/29/110000)
 - [授業参観に行ったらネットリテラシー講座がセキュリティソフトの営業会場になっていた話](https://togetter.com/li/2569535)
-- [オープンＡＩ、グーグル半導体を使用　初の非エヌビディア製か](https://jp.reuters.com/economy/industry/LQW3LAQ5WJMGDPMOEABXN2E3MM-2025-06-29/)
 
 
 ---
 ## <img src="https://b.hatena.ne.jp/favicon.ico" width="16" height="16" alt="はてなブックマーク - IT（新着）"> はてなブックマーク - IT（新着）
 
+- [GoogleのAI「Gemini」をScale AIがトレーニングしようとしたら未審査のフリーランサーによるあまりにも粗悪な仕事が横行していたことが判明](https://gigazine.net/news/20250630-scale-ai-google-gemini-spam-problem/)
+- [Win 11対応PCを家族や友人に譲るなら、「Sysprep」で“不要なアプリを削除した初期化環境”を作るべし！【イニシャルB】](https://internet.watch.impress.co.jp/docs/column/shimizu/2024741.html)
 - [「Windows 11 バージョン 25H2」のテストが開始、正式リリースは2025年後半／次期機能更新プログラム、「バージョン 24H2」とはコード共通で「eKB」による切り替え](https://forest.watch.impress.co.jp/docs/news/2026720.html)
 - [なぜ今、研究者はGeminiを選ぶべきか？他のAIとの比較で見る10のメリット｜genkAIjokyo|ChatGPT/Claudeで論文作成と科研費申請](https://note.com/genkaijokyo/n/nfb96a13e084f)
 - [Visual Studio CodeのAIエディタ化が前進、GitHub Copilot Chatがオープンソースで公開。現在プレリリース版](https://www.publickey1.jp/blog/25/visual_studio_codeaigithub_copilot_chat.html)
-- [GitHub - microsoft/vscode-copilot-chat: Copilot Chat extension for VS Code](https://github.com/microsoft/vscode-copilot-chat)
-- [Claude CodeのTaskツールの並列実行（parallelTasksCount）は分析タスク向け](https://blog.lai.so/claude-code-parallel-tasks/)
 
 
 ---
 ## <img src="https://dev.classmethod.jp/favicon.ico" width="16" height="16" alt="DevelopersIO"> DevelopersIO
 
-- [Claude Code を活用！Webアクセス解析レポートの作成と S3 公開を自動化してみた](https://dev.classmethod.jp/articles/creating-web-access-report-and-uploading-s3-with-claude-code/)
+- [Claude Code を活用！Webアクセス解析レポートの作成と S3 公開を自動化してみた](https://dev.classmethod.jp/articles/creating-web-access-report-and-uploading-s3-claude-code/)
 - [AWS WAF 新コンソールの「保護パック」を新規作成する時に、何をどう選択したら良いのか調べてみた](https://dev.classmethod.jp/articles/waf-protection-pack/)
 - [Amazon Connect Customer Profilesに登録された全顧客の一覧を取得する方法](https://dev.classmethod.jp/articles/amazon-connect-customer-profiles-profile-list/)
 - [[アップデート] Amazon CloudWatch の運用調査機能が一般提供を開始したため、概要をまとめてみた](https://dev.classmethod.jp/articles/ga-accelerate-troubleshooting-amazon-cloudwatch-investigations/)
@@ -111,21 +111,22 @@ https://unsolublesugar.github.io/daily-tech-news/
 ---
 ## <img src="https://connpass.com/favicon.ico" width="16" height="16" alt="connpass - イベント"> connpass - イベント
 
+- [実践！バックエンドTypeScript〜現場から学ぶtsの可能性〜](https://findy.connpass.com/event/360678/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
+- [JAWS-UG金沢 #105 AWS Summit 振り返りLT会](https://jawsug-kanazawa.connpass.com/event/360910/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
+- [#84 JAWS-UG主催 週刊AWSキャッチアップ （2025/6/16&23週）](https://jaws-ug.connpass.com/event/360939/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
+- [早朝オンライン[Math & Coding] 多様体の基礎 #97](https://math-coding.connpass.com/event/360940/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [オープンハードカンファレンスミーティング](https://openforce.connpass.com/event/360937/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [現場が変わる！Smartsheet でタスクの定型業務の自動化と可視化](https://xlsoftdevops.connpass.com/event/360772/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [ssmonline #49](https://ssmjp.connpass.com/event/358686/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [ハードウェア技術誌を読もう：トランジスタ技術最新号よみあわせ解説会(2025年9月号)](https://engineercafe.connpass.com/event/360029/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [ハードウェア技術誌を読もう：トランジスタ技術最新号よみあわせ解説会(2025年8月号)](https://engineercafe.connpass.com/event/360005/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 - [第103回 Machine Learning 15minutes! Hybrid](https://machine-learning15minutes.connpass.com/event/360928/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
-- [Arduino Uno R4ボードを設計しようプロジェクト #1](https://engineercafe.connpass.com/event/358631/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
-- [第131回 なごや個人開発者の集い](https://758indies.connpass.com/event/360927/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
-- [『初級ウクライナ語文法』勉強会(17)](https://elem-ukrainian.connpass.com/event/360925/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
-- [Shikumi.rb #7](https://shikumirb.connpass.com/event/360924/?utm_campaign=recent_events&utm_source=feed&utm_medium=atom)
 
 
 ---
 ## <img src="https://techplay.jp/favicon.ico" width="16" height="16" alt="TECH PLAY - イベント"> TECH PLAY - イベント
 
+- [実践！バックエンドTypeScript〜現場から学ぶtsの可能性〜](https://techplay.jp/event/983039)
 - [現場が変わる！Smartsheet でタスクの定型業務の自動化と可視化](https://techplay.jp/event/983083)
 - [SnowVillage Unconference #6　– 初心者大歓迎！聞き専/飛入登壇, ご自由なスタイルで！](https://techplay.jp/event/983108)
 - [7/11(金)開催　初心者でもわかる基本用語解説セミナー](https://techplay.jp/event/983102)
@@ -135,7 +136,6 @@ https://unsolublesugar.github.io/daily-tech-news/
 - [〜Tableau tuneup Vol.15 ~初心者相談室×Tabもく会~](https://techplay.jp/event/982480)
 - [ネットワークハンズオン（CCNA実習、AWS接続・L3スイッチ・ファイアウォール実習）](https://techplay.jp/event/983092)
 - [AWS Discovery Day 2025 in Winスクール](https://techplay.jp/event/982852)
-- [独学もオンラインも無理だから「永田町Pythonミニキャンプ」【5日間5万円】](https://techplay.jp/event/983086)
 
 
 ---

--- a/archives/2025/06/index.html
+++ b/archives/2025/06/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>2025年6月のテックニュース</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            line-height: 1.6;
+            color: #333;
+        }
+        h1 {
+            color: #1f2328;
+        }
+        ul {
+            list-style-type: disc;
+            padding-left: 2em;
+        }
+        li {
+            margin: 8px 0;
+        }
+        a {
+            color: #0969da;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        .back-link {
+            margin-top: 30px;
+            padding-top: 20px;
+            border-top: 1px solid #e1e5e9;
+        }
+    </style>
+</head>
+<body>
+    <h1>2025年6月のテックニュース</h1>
+    
+    <p>2025年6月に取得したテックニュースの一覧です。</p>
+    
+    <ul>
+        <li><a href="2025-06-30.html">2025-06-30</a></li>
+        <li><a href="2025-06-29.html">2025-06-29</a></li>
+    </ul>
+    
+    <div class="back-link">
+        <p><a href="../index.html">← 2025年一覧に戻る</a></p>
+    </div>
+</body>
+</html>

--- a/archives/2025/index.html
+++ b/archives/2025/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>2025年のテックニュース</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            line-height: 1.6;
+            color: #333;
+        }
+        h1 {
+            color: #1f2328;
+        }
+        ul {
+            list-style-type: disc;
+            padding-left: 2em;
+        }
+        li {
+            margin: 8px 0;
+        }
+        a {
+            color: #0969da;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        .back-link {
+            margin-top: 30px;
+            padding-top: 20px;
+            border-top: 1px solid #e1e5e9;
+        }
+    </style>
+</head>
+<body>
+    <h1>2025年のテックニュース</h1>
+    
+    <p>2025年に取得したテックニュースの月別一覧です。</p>
+    
+    <ul>
+        <li><a href="06/index.html">2025年6月</a></li>
+    </ul>
+    
+    <div class="back-link">
+        <p><a href="../index.html">← アーカイブ一覧に戻る</a></p>
+    </div>
+</body>
+</html>

--- a/archives/index.html
+++ b/archives/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>テックニュース アーカイブ</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            line-height: 1.6;
+            color: #333;
+        }
+        h1 {
+            color: #1f2328;
+        }
+        ul {
+            list-style-type: disc;
+            padding-left: 2em;
+        }
+        li {
+            margin: 8px 0;
+        }
+        a {
+            color: #0969da;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        .back-link {
+            margin-top: 30px;
+            padding-top: 20px;
+            border-top: 1px solid #e1e5e9;
+        }
+    </style>
+</head>
+<body>
+    <h1>テックニュース アーカイブ</h1>
+    
+    <p>過去のテックニュースの年別アーカイブです。</p>
+    
+    <ul>
+        <li><a href="2025/index.html">2025年</a></li>
+    </ul>
+    
+    <div class="back-link">
+        <p><a href="../index.html">← メインページに戻る</a></p>
+    </div>
+</body>
+</html>

--- a/fetch_news.py
+++ b/fetch_news.py
@@ -655,8 +655,208 @@ https://unsolublesugar.github.io/daily-tech-news/
     
     return markdown
 
-def save_to_archive(content, date_obj):
-    """日付別アーカイブファイルとして保存"""
+def generate_archive_markdown(all_entries, feed_info, date_str):
+    """アーカイブ用のMarkdownコンテンツを生成する（相対パス修正版）"""
+    markdown = f"# 今日のテックニュース ({date_str})\n\n"
+    markdown += """📚 [過去のニュースを見る](../../index.md) | 🎨 [カード表示版を見る](https://unsolublesugar.github.io/daily-tech-news/) | 📡 [RSSフィードを購読](https://unsolublesugar.github.io/daily-tech-news/rss.xml)
+
+日本の主要な技術系メディアの最新人気エントリーをお届けします。
+
+※毎日JST 7:00に自動更新
+
+## 🎨 カード表示版もあります
+
+GitHub Pages版では各記事がカード形式で見やすく表示されます：  
+https://unsolublesugar.github.io/daily-tech-news/
+
+---
+"""
+
+    for feed_name, entries in all_entries.items():
+        favicon = feed_info[feed_name]["favicon"]
+        if favicon.startswith("http"):
+            # ファビコンURLの場合
+            favicon_display = f'<img src="{favicon}" width="16" height="16" alt="{feed_name}">'
+        else:
+            # 絵文字の場合
+            favicon_display = favicon
+        markdown += f"## {favicon_display} {feed_name}\n\n"
+        if not entries:
+            markdown += "記事を取得できませんでした。\n"
+        else:
+            # エントリーはすでにURL重複除去済み
+            for entry in entries:
+                title = entry.title
+                link = entry.link
+                
+                # シンプルなリンク形式で表示
+                markdown += f"- [{title}]({link})\n"
+        
+        markdown += "\n\n---\n"
+    
+    markdown += "## License\n\nThis project is licensed under the [MIT License](LICENSE).\n"
+    
+    return markdown
+
+def generate_archive_html(all_entries, feed_info, date_str, thumbnails=None):
+    """アーカイブ用のHTMLコンテンツを生成する"""
+    site_title = f"今日のテックニュース ({date_str})"
+    site_description = "日本の主要な技術系メディアの最新人気エントリーを毎日お届けします。"
+    site_url = "https://unsolublesugar.github.io/daily-tech-news/"
+    og_image_url = f"{site_url}assets/images/OGP.png"
+    twitter_user = "@unsoluble_sugar"
+
+    html = f"""<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{site_title}</title>
+    
+    <!-- OGP Tags -->
+    <meta property="og:title" content="{site_title}">
+    <meta property="og:description" content="{site_description}">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{site_url}">
+    <meta property="og:image" content="{og_image_url}">
+    <meta property="og:site_name" content="今日のテックニュース">
+    
+    <!-- Twitter Card Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="{twitter_user}">
+    
+    <style>
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            line-height: 1.6;
+            color: #333;
+        }}
+        .card {{
+            border: 1px solid #e1e5e9;
+            padding: 15px;
+            margin: 15px 0;
+            border-radius: 8px;
+            background-color: #f8f9fa;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            transition: box-shadow 0.2s ease;
+            text-decoration: none;
+            color: inherit;
+            display: block;
+        }}
+        .card:hover {{
+            box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+        }}
+        .card-content {{
+            display: flex;
+            align-items: flex-start;
+            gap: 15px;
+        }}
+        .card-image {{
+            border-radius: 6px;
+            object-fit: cover;
+            flex-shrink: 0;
+        }}
+        .card-text {{
+            flex: 1;
+        }}
+        .card-title {{
+            margin: 0 0 8px 0;
+            font-size: 16px;
+            line-height: 1.4;
+            color: #0969da;
+            font-weight: 600;
+        }}
+        .card-source {{
+            margin: 0;
+            font-size: 12px;
+            color: #656d76;
+        }}
+        h1, h2 {{
+            color: #1f2328;
+        }}
+        .rss-info {{
+            background: #f6f8fa;
+            padding: 16px;
+            border-radius: 8px;
+            margin: 20px 0;
+        }}
+        .footer {{
+            margin-top: 40px;
+            padding: 20px 0;
+            border-top: 1px solid #e1e5e9;
+            text-align: center;
+            font-size: 14px;
+            color: #656d76;
+        }}
+        .footer a {{
+            color: #0969da;
+            text-decoration: none;
+        }}
+        .footer a:hover {{
+            text-decoration: underline;
+        }}
+    </style>
+</head>
+<body>
+    <h1>{site_title}</h1>
+    
+    <p>📚 <a href="../../index.html">過去のニュースを見る</a> | 📡 <a href="https://unsolublesugar.github.io/daily-tech-news/rss.xml">RSSフィードを購読</a></p>
+    
+    <p>日本の主要な技術系メディアの最新人気エントリーをお届けします。</p>
+    
+    <div class="rss-info">
+        <p>毎日JST 7:00に自動更新</p>
+    </div>
+    
+    <hr>
+"""
+    
+    for feed_name, entries in all_entries.items():
+        favicon = feed_info[feed_name]["favicon"]
+        if favicon.startswith("http"):
+            favicon_display = f'<img src="{favicon}" width="16" height="16" alt="{feed_name}">'
+        else:
+            favicon_display = favicon
+        
+        html += f"    <h2>{favicon_display} {feed_name}</h2>\n"
+        
+        if not entries:
+            html += "    <p>記事を取得できませんでした。</p>\n"
+        else:
+            # エントリーはすでにURL重複除去済み
+            for entry in entries:
+                title = entry.title
+                link = entry.link
+                
+                # 事前取得済みのサムネイルを使用
+                thumbnail_url = thumbnails.get(link) if thumbnails else None
+                
+                escaped_title = title.replace('"', '&quot;').replace('<', '&lt;').replace('>', '&gt;')
+                
+                if thumbnail_url:
+                    escaped_url = thumbnail_url.replace('"', '&quot;').replace('<', '&lt;').replace('>', '&gt;')
+                    card_html = f'    <a href="{link}" class="card">\n        <div class="card-content">\n            <img src="{escaped_url}" width="120" height="90" alt="{escaped_title}" class="card-image">\n            <div class="card-text">\n                <h4 class="card-title">{title}</h4>\n                <p class="card-source">{feed_name}</p>\n            </div>\n        </div>\n    </a>\n'
+                else:
+                    card_html = f'    <a href="{link}" class="card">\n        <div class="card-content">\n            <div class="card-text">\n                <h4 class="card-title">{title}</h4>\n                <p class="card-source">{feed_name}</p>\n            </div>\n        </div>\n    </a>\n'
+                html += card_html
+        
+        html += "    <hr>\n"
+    
+    html += """
+    <div class="footer">
+        <p>🚀 運営者: <a href="https://x.com/unsoluble_sugar" target="_blank" rel="noopener">@unsoluble_sugar</a> | 
+        📁 <a href="https://github.com/unsolublesugar/daily-tech-news" target="_blank" rel="noopener">GitHub Repository</a></p>
+    </div>
+</body>
+</html>"""
+    
+    return html
+
+def save_to_archive(all_entries, feed_info, date_obj, thumbnails=None):
+    """日付別アーカイブファイルとして保存（MarkdownとHTML両方）"""
     year = date_obj.year
     month = f"{date_obj.month:02d}"
     date_str = date_obj.isoformat()
@@ -665,7 +865,8 @@ def save_to_archive(content, date_obj):
     archive_dir = Path(f"archives/{year}/{month}")
     archive_dir.mkdir(parents=True, exist_ok=True)
     
-    # ファイル保存（既存ファイルは上書き）
+    # Markdown版
+    md_content = generate_archive_markdown(all_entries, feed_info, date_str)
     archive_file = archive_dir / f"{date_str}.md"
     if archive_file.exists():
         print(f"Overwriting existing archive: {archive_file}")
@@ -673,12 +874,21 @@ def save_to_archive(content, date_obj):
         print(f"Creating new archive: {archive_file}")
     
     with open(archive_file, "w", encoding="utf-8") as f:
-        f.write(content)
+        f.write(md_content)
+    
+    # HTML版
+    html_content = generate_archive_html(all_entries, feed_info, date_str, thumbnails)
+    html_file = archive_dir / f"{date_str}.html"
+    
+    with open(html_file, "w", encoding="utf-8") as f:
+        f.write(html_content)
+    
+    print(f"Generated archive files: {archive_file} and {html_file}")
     
     return archive_file
 
 def update_monthly_index(year, month):
-    """月別インデックスページを更新"""
+    """月別インデックスページを更新（MarkdownとHTML両方）"""
     archive_dir = Path(f"archives/{year}/{month:02d}")
     if not archive_dir.exists():
         return
@@ -686,21 +896,84 @@ def update_monthly_index(year, month):
     # その月のファイル一覧を取得
     md_files = sorted([f for f in archive_dir.iterdir() if f.suffix == '.md' and f.name != 'index.md'])
     
-    # 月別インデックス作成
-    index_content = f"# {year}年{month}月のテックニュース\n\n"
-    index_content += f"{year}年{month}月に取得したテックニュースの一覧です。\n\n"
+    # Markdown版
+    md_content = f"# {year}年{month}月のテックニュース\n\n"
+    md_content += f"{year}年{month}月に取得したテックニュースの一覧です。\n\n"
     
     for md_file in reversed(md_files):  # 新しい順
         date_str = md_file.stem
-        index_content += f"- [{date_str}]({md_file.name})\n"
+        md_content += f"- [{date_str}]({md_file.name})\n"
     
-    index_content += f"\n[← {year}年一覧に戻る](../index.md)\n"
+    md_content += f"\n[← {year}年一覧に戻る](../index.md)\n"
     
     with open(archive_dir / "index.md", "w", encoding="utf-8") as f:
-        f.write(index_content)
+        f.write(md_content)
+    
+    # HTML版
+    html_content = f"""<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{year}年{month}月のテックニュース</title>
+    <style>
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            line-height: 1.6;
+            color: #333;
+        }}
+        h1 {{
+            color: #1f2328;
+        }}
+        ul {{
+            list-style-type: disc;
+            padding-left: 2em;
+        }}
+        li {{
+            margin: 8px 0;
+        }}
+        a {{
+            color: #0969da;
+            text-decoration: none;
+        }}
+        a:hover {{
+            text-decoration: underline;
+        }}
+        .back-link {{
+            margin-top: 30px;
+            padding-top: 20px;
+            border-top: 1px solid #e1e5e9;
+        }}
+    </style>
+</head>
+<body>
+    <h1>{year}年{month}月のテックニュース</h1>
+    
+    <p>{year}年{month}月に取得したテックニュースの一覧です。</p>
+    
+    <ul>"""
+    
+    for md_file in reversed(md_files):  # 新しい順
+        date_str = md_file.stem
+        html_content += f'\n        <li><a href="{date_str}.html">{date_str}</a></li>'
+    
+    html_content += f"""
+    </ul>
+    
+    <div class="back-link">
+        <p><a href="../index.html">← {year}年一覧に戻る</a></p>
+    </div>
+</body>
+</html>"""
+    
+    with open(archive_dir / "index.html", "w", encoding="utf-8") as f:
+        f.write(html_content)
 
 def update_yearly_index(year):
-    """年別インデックスページを更新"""
+    """年別インデックスページを更新（MarkdownとHTML両方）"""
     year_dir = Path(f"archives/{year}")
     if not year_dir.exists():
         return
@@ -708,40 +981,322 @@ def update_yearly_index(year):
     # その年の月ディレクトリ一覧を取得
     month_dirs = sorted([d for d in year_dir.iterdir() if d.is_dir() and d.name.isdigit()])
     
-    # 年別インデックス作成
-    index_content = f"# {year}年のテックニュース\n\n"
-    index_content += f"{year}年に取得したテックニュースの月別一覧です。\n\n"
+    # Markdown版
+    md_content = f"# {year}年のテックニュース\n\n"
+    md_content += f"{year}年に取得したテックニュースの月別一覧です。\n\n"
     
     for month_dir in reversed(month_dirs):  # 新しい順
         month = int(month_dir.name)
-        index_content += f"- [{year}年{month}月]({month_dir.name}/index.md)\n"
+        md_content += f"- [{year}年{month}月]({month_dir.name}/index.md)\n"
     
-    index_content += f"\n[← アーカイブ一覧に戻る](../index.md)\n"
+    md_content += f"\n[← アーカイブ一覧に戻る](../index.md)\n"
     
     with open(year_dir / "index.md", "w", encoding="utf-8") as f:
-        f.write(index_content)
+        f.write(md_content)
+    
+    # HTML版
+    html_content = f"""<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{year}年のテックニュース</title>
+    <style>
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            line-height: 1.6;
+            color: #333;
+        }}
+        h1 {{
+            color: #1f2328;
+        }}
+        ul {{
+            list-style-type: disc;
+            padding-left: 2em;
+        }}
+        li {{
+            margin: 8px 0;
+        }}
+        a {{
+            color: #0969da;
+            text-decoration: none;
+        }}
+        a:hover {{
+            text-decoration: underline;
+        }}
+        .back-link {{
+            margin-top: 30px;
+            padding-top: 20px;
+            border-top: 1px solid #e1e5e9;
+        }}
+    </style>
+</head>
+<body>
+    <h1>{year}年のテックニュース</h1>
+    
+    <p>{year}年に取得したテックニュースの月別一覧です。</p>
+    
+    <ul>"""
+    
+    for month_dir in reversed(month_dirs):  # 新しい順
+        month = int(month_dir.name)
+        html_content += f'\n        <li><a href="{month_dir.name}/index.html">{year}年{month}月</a></li>'
+    
+    html_content += f"""
+    </ul>
+    
+    <div class="back-link">
+        <p><a href="../index.html">← アーカイブ一覧に戻る</a></p>
+    </div>
+</body>
+</html>"""
+    
+    with open(year_dir / "index.html", "w", encoding="utf-8") as f:
+        f.write(html_content)
 
-def update_archive_index():
-    """アーカイブ全体のインデックスページを更新"""
+def generate_missing_html_archives():
+    """既存のMarkdownアーカイブファイルに対応するHTMLファイルが存在しない場合に生成する"""
     archives_dir = Path("archives")
     if not archives_dir.exists():
         return
     
+    # 全てのMarkdownアーカイブファイルを検索
+    md_files = list(archives_dir.glob("**/????-??-??.md"))
+    
+    for md_file in md_files:
+        html_file = md_file.with_suffix('.html')
+        
+        # HTMLファイルが存在しない場合のみ生成
+        if not html_file.exists():
+            print(f"Generating missing HTML archive: {html_file}")
+            
+            # Markdownファイルからコンテンツを読み取り、簡易的にHTMLに変換
+            try:
+                with open(md_file, 'r', encoding='utf-8') as f:
+                    md_content = f.read()
+                
+                # 日付を抽出
+                date_match = re.search(r'# 今日のテックニュース \((\d{4}-\d{2}-\d{2})\)', md_content)
+                if date_match:
+                    date_str = date_match.group(1)
+                    
+                    # 簡易的なHTML生成（完全な記事リスト無しでも基本構造を生成）
+                    html_content = f"""<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>今日のテックニュース ({date_str})</title>
+    
+    <!-- OGP Tags -->
+    <meta property="og:title" content="今日のテックニュース ({date_str})">
+    <meta property="og:description" content="日本の主要な技術系メディアの最新人気エントリーを毎日お届けします。">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://unsolublesugar.github.io/daily-tech-news/">
+    <meta property="og:image" content="https://unsolublesugar.github.io/daily-tech-news/assets/images/OGP.png">
+    <meta property="og:site_name" content="今日のテックニュース">
+    
+    <!-- Twitter Card Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="@unsoluble_sugar">
+    
+    <style>
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            line-height: 1.6;
+            color: #333;
+        }}
+        h1, h2 {{
+            color: #1f2328;
+        }}
+        a {{
+            color: #0969da;
+            text-decoration: none;
+        }}
+        a:hover {{
+            text-decoration: underline;
+        }}
+        .rss-info {{
+            background: #f6f8fa;
+            padding: 16px;
+            border-radius: 8px;
+            margin: 20px 0;
+        }}
+        .footer {{
+            margin-top: 40px;
+            padding: 20px 0;
+            border-top: 1px solid #e1e5e9;
+            text-align: center;
+            font-size: 14px;
+            color: #656d76;
+        }}
+        .footer a {{
+            color: #0969da;
+            text-decoration: none;
+        }}
+        .footer a:hover {{
+            text-decoration: underline;
+        }}
+        ul {{
+            line-height: 1.8;
+        }}
+    </style>
+</head>
+<body>
+    <h1>今日のテックニュース ({date_str})</h1>
+    
+    <p>📚 <a href="../../index.html">過去のニュースを見る</a> | 📡 <a href="https://unsolublesugar.github.io/daily-tech-news/rss.xml">RSSフィードを購読</a></p>
+    
+    <p>日本の主要な技術系メディアの最新人気エントリーをお届けします。</p>
+    
+    <div class="rss-info">
+        <p>毎日JST 7:00に自動更新</p>
+    </div>
+    
+    <hr>
+"""
+                    
+                    # Markdownの内容を簡易的にHTMLに変換
+                    lines = md_content.split('\n')
+                    in_list = False
+                    current_section = None
+                    
+                    for line in lines:
+                        line = line.strip()
+                        if not line:
+                            continue
+                            
+                        # セクションヘッダー
+                        if line.startswith('## ') and not line.startswith('## License'):
+                            if in_list:
+                                html_content += "    </ul>\n    <hr>\n"
+                                in_list = False
+                            
+                            section_title = line[3:].strip()
+                            html_content += f"    <h2>{section_title}</h2>\n"
+                            current_section = section_title
+                            
+                        # リスト項目
+                        elif line.startswith('- [') and current_section and 'License' not in current_section:
+                            if not in_list:
+                                html_content += "    <ul>\n"
+                                in_list = True
+                            
+                            # リンクを抽出
+                            link_match = re.match(r'- \[([^\]]+)\]\(([^)]+)\)', line)
+                            if link_match:
+                                title, url = link_match.groups()
+                                html_content += f'        <li><a href="{url}">{title}</a></li>\n'
+                    
+                    if in_list:
+                        html_content += "    </ul>\n    <hr>\n"
+                    
+                    html_content += """
+    <div class="footer">
+        <p>🚀 運営者: <a href="https://x.com/unsoluble_sugar" target="_blank" rel="noopener">@unsoluble_sugar</a> | 
+        📁 <a href="https://github.com/unsolublesugar/daily-tech-news" target="_blank" rel="noopener">GitHub Repository</a></p>
+    </div>
+</body>
+</html>"""
+                    
+                    with open(html_file, 'w', encoding='utf-8') as f:
+                        f.write(html_content)
+                        
+            except Exception as e:
+                print(f"Error generating HTML for {md_file}: {e}")
+
+def update_archive_index():
+    """アーカイブ全体のインデックスページを更新（MarkdownとHTML両方）"""
+    archives_dir = Path("archives")
+    if not archives_dir.exists():
+        return
+    
+    # 既存のMarkdownファイルに対応するHTMLファイルを生成
+    generate_missing_html_archives()
+    
     # 年ディレクトリ一覧を取得
     year_dirs = sorted([d for d in archives_dir.iterdir() if d.is_dir() and d.name.isdigit()])
     
-    # アーカイブインデックス作成
-    index_content = "# テックニュース アーカイブ\n\n"
-    index_content += "過去のテックニュースの年別アーカイブです。\n\n"
+    # Markdown版（README.mdからの遷移用）
+    md_content = "# テックニュース アーカイブ\n\n"
+    md_content += "過去のテックニュースの年別アーカイブです。\n\n"
     
     for year_dir in reversed(year_dirs):  # 新しい順
         year = year_dir.name
-        index_content += f"- [{year}年]({year}/index.md)\n"
+        md_content += f"- [{year}年]({year}/index.md)\n"
     
-    index_content += f"\n[← メインページに戻る](../README.md)\n"
-    
+    md_content += f"\n[← メインページに戻る](../README.md)\n"
     with open(archives_dir / "index.md", "w", encoding="utf-8") as f:
-        f.write(index_content)
+        f.write(md_content)
+    
+    # HTML版（index.htmlからの遷移用）
+    html_content = """<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>テックニュース アーカイブ</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            line-height: 1.6;
+            color: #333;
+        }
+        h1 {
+            color: #1f2328;
+        }
+        ul {
+            list-style-type: disc;
+            padding-left: 2em;
+        }
+        li {
+            margin: 8px 0;
+        }
+        a {
+            color: #0969da;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        .back-link {
+            margin-top: 30px;
+            padding-top: 20px;
+            border-top: 1px solid #e1e5e9;
+        }
+    </style>
+</head>
+<body>
+    <h1>テックニュース アーカイブ</h1>
+    
+    <p>過去のテックニュースの年別アーカイブです。</p>
+    
+    <ul>"""
+    
+    for year_dir in reversed(year_dirs):  # 新しい順
+        year = year_dir.name
+        html_content += f'\n        <li><a href="{year}/index.html">{year}年</a></li>'
+    
+    html_content += """
+    </ul>
+    
+    <div class="back-link">
+        <p><a href="../index.html">← メインページに戻る</a></p>
+    </div>
+</body>
+</html>"""
+    
+    with open(archives_dir / "index.html", "w", encoding="utf-8") as f:
+        f.write(html_content)
 
 def update_readme_with_archive_link(content):
     """README.mdにアーカイブとRSSへのリンクを追加（既に含まれている場合はそのまま）"""
@@ -910,7 +1465,7 @@ if __name__ == "__main__":
     html_content = generate_html(all_entries, FEEDS, today.isoformat(), thumbnails)
     
     # アーカイブに保存
-    archive_file = save_to_archive(markdown_content, today)
+    archive_file = save_to_archive(all_entries, FEEDS, today, thumbnails)
     print(f"Archived to: {archive_file}")
     
     # インデックスページ更新


### PR DESCRIPTION
Fixes #43

## 変更内容
- 全アーカイブレベル（ルート・年・月・日付）でHTML版とMarkdown版の両方を生成
- アーカイブページの「メインページに戻る」リンクが正しく動作するよう修正
- HTML版アーカイブページでの適切なHTML構造表示を実装
- 既存Markdownアーカイブファイルに対応するHTMLファイルの自動生成機能を追加
- アーカイブコンテンツ内の相対パスリンクを修正

## 修正された問題
1. **リンク切れ問題**: カード表示版から「Return to Main Page」をクリックした際にREADME.mdではなく適切なページに遷移
2. **HTML表示問題**: HTML版アーカイブページがテキスト表示されていた問題を修正
3. **欠損ファイル問題**: 2025-06-29.htmlなど欠損していたHTMLファイルを自動生成

## 技術的な変更
- **fetch_news.py**に以下の新機能を追加：
  - `generate_archive_markdown()` と `generate_archive_html()`: 適切なコンテンツ生成
  - `generate_missing_html_archives()`: 欠損HTMLファイルの自動生成
  - `save_to_archive()`: 両形式での保存と正しい相対パス設定
  - 月別・年別・ルートインデックスの双方向生成対応

- **デュアルナビゲーション戦略**:
  - Markdownファイル: `../README.md`へのリンク（ローカルナビゲーション用）
  - HTMLファイル: `../index.html`へのリンク（GitHub Pages用）

## テスト方法
- [x] HTML版アーカイブページが正しく表示される（テキスト表示ではない）
- [x] 「メインページに戻る」リンクが両コンテキストで動作する
- [x] 全アーカイブレベルで適切なナビゲーションが機能する
- [x] 欠損HTMLファイルが自動生成される
- [x] 相対パスリンクが全ディレクトリレベルで正しく動作する

## 関連Issue
Fixes #43 - アーカイブページの「Return to Main Page」リンク修正とHTML表示問題解決