### PR TITLE
🐛 修正: GitHub Actionsのコミットメッセージ日付がUTC基準になっている問題を解決 (#51)

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -50,7 +50,8 @@ jobs:
         if git diff --staged --quiet; then
           echo "No changes to commit"
         else
-          git commit -m "🗞️ 毎日のテックニュース更新 $(date '+%Y-%m-%d')"
+          # JSTタイムゾーンで日付を取得
+          git commit -m "🗞️ 毎日のテックニュース更新 $(TZ=Asia/Tokyo date '+%Y-%m-%d')"
           git push
         fi
         


### PR DESCRIPTION
Fixes #51

## 変更内容

GitHub Actions ワークフローでのコミットメッセージ生成時に、JSTタイムゾーン（Asia/Tokyo）を明示的に指定するよう修正しました。

### 問題

現在のワークフローでは `$(date '+%Y-%m-%d')` でUTCサーバー時刻を使用しているため、JST 7:00（UTC 22:00）の実行時にコミットメッセージの日付が前日になってしまいます。

### 修正内容

**変更前:**
```bash
git commit -m "🗞️ 毎日のテックニュース更新 $(date '+%Y-%m-%d')"
```

**変更後:**
```bash
# JSTタイムゾーンで日付を取得
git commit -m "🗞️ 毎日のテックニュース更新 $(TZ=Asia/Tokyo date '+%Y-%m-%d')"
```

## テスト方法

次回のワークフロー実行時（JST 7:00）に、コミットメッセージの日付が正しく表示されることを確認。

## 影響範囲

- GitHub Actions ワークフローファイルのみ
- 既存の機能には影響なし
- 次回実行から正しい日付が表示される