### PR TITLE
🔧 修正: アーカイブページから自動更新記載を削除 (#55)

### DIFF
--- a/fetch_news.py
+++ b/fetch_news.py
@@ -691,8 +691,6 @@ def generate_archive_markdown(all_entries, feed_info, date_str):
 
 日本の主要な技術系メディアの最新人気エントリーをお届けします。
 
-※毎日JST 7:00に自動更新
-
 ## 🎨 カード表示版もあります
 
 GitHub Pages版では各記事がカード形式で見やすく表示されます：  
@@ -863,10 +861,6 @@ def generate_archive_html(all_entries, feed_info, date_str, thumbnails=None):
     <p><a href="https://twitter.com/intent/tweet?text=👨‍💻 今日のテックニュース ({date_str}) をチェック！&url={site_url}archives/{date_str.replace('-', '/')}/{date_str}.html&hashtags=techhunter" target="_blank" rel="noopener" class="share-button"><span class="x-logo"></span>シェア</a> | 📚 <a href="../../index.html">過去のニュースを見る</a></p>
     
     <p>日本の主要な技術系メディアの最新人気エントリーをお届けします。</p>
-    
-    <div class="rss-info">
-        <p>毎日JST 7:00に自動更新</p>
-    </div>
     
     <hr>
 """


### PR DESCRIPTION
Fixes #55

## 問題

アーカイブページに「※毎日JST 7:00に自動更新」という記載が表示されていましたが、これは不正確でした。

- **トップページ**: 毎日自動更新される ✅ 記載が必要
- **アーカイブページ**: 過去の静的コンテンツ ❌ 記載は不要

## 修正内容

### 🔧 HTMLアーカイブページ
- **ファイル**: `generate_archive_html()` 関数
- **削除**: `<div class="rss-info"><p>毎日JST 7:00に自動更新</p></div>`

### 🔧 Markdownアーカイブページ
- **ファイル**: `generate_archive_markdown()` 関数  
- **削除**: `※毎日JST 7:00に自動更新`

## 修正結果

### Before ❌
```
日本の主要な技術系メディアの最新人気エントリーをお届けします。

※毎日JST 7:00に自動更新  ← 不正確

---
```

### After ✅  
```
日本の主要な技術系メディアの最新人気エントリーをお届けします。

---  ← 自動更新記載を削除
```

## 影響範囲

- ✅ **トップページ**: 自動更新記載は維持（正しい）
- ✅ **アーカイブページ**: 自動更新記載を削除（修正完了）
- 📅 **既存アーカイブ**: 次回の自動実行時に更新される

## テスト確認

- ✅ アーカイブHTML関数から記載削除
- ✅ アーカイブMarkdown関数から記載削除  
- ✅ トップページの記載は維持
- ✅ 他の機能に影響なし