### PR TITLE
🎨 UI改善: カテゴリ間の水平線を削除して見栄えを向上 (#57)

### DIFF
--- a/fetch_news.py
+++ b/fetch_news.py
@@ -627,8 +627,6 @@ def generate_html(all_entries, feed_info, date_str, thumbnails=None):
                 else:
                     card_html = f'    <a href="{link}" class="card">\n        <div class="card-content">\n            <div class="card-text">\n                <h4 class="card-title">{title}</h4>\n                <p class="card-source">{feed_name}</p>\n            </div>\n        </div>\n    </a>\n'
                 html += card_html
-        
-        html += "    <hr>\n"
     
     html += """
     <div class="footer">
@@ -893,8 +891,6 @@ def generate_archive_html(all_entries, feed_info, date_str, thumbnails=None):
                 else:
                     card_html = f'    <a href="{link}" class="card">\n        <div class="card-content">\n            <div class="card-text">\n                <h4 class="card-title">{title}</h4>\n                <p class="card-source">{feed_name}</p>\n            </div>\n        </div>\n    </a>\n'
                 html += card_html
-        
-        html += "    <hr>\n"
     
     html += """
     <div class="footer">


### PR DESCRIPTION
Closes #57

## 問題

各ニュースカテゴリ（Tech Blog Weekly、Zenn、Qiita等）の間に水平線（`<hr>`）が表示されており、見栄え上よろしくない状況でした。

## 🎨 UI改善内容

### 水平線削除
- **メインページ**: `generate_html()` 関数のカテゴリループから `<hr>` タグを削除
- **アーカイブページ**: `generate_archive_html()` 関数のカテゴリループから `<hr>` タグを削除

## ✨ 改善効果

### Before ❌
```html
<h2>💻 Tech Blog Weekly</h2>
[記事カード一覧]
<hr>  ← 見栄えがよろしくない水平線

<h2>⚡ Zenn</h2>
[記事カード一覧]  
<hr>  ← 見栄えがよろしくない水平線

<h2>📚 Qiita</h2>
[記事カード一覧]
<hr>  ← 見栄えがよろしくない水平線
```

### After ✅
```html
<h2>💻 Tech Blog Weekly</h2>
[記事カード一覧]

<h2>⚡ Zenn</h2>  ← 自然な間隔でスッキリ
[記事カード一覧]

<h2>📚 Qiita</h2>  ← 自然な間隔でスッキリ
[記事カード一覧]
```

## 🎯 達成した改善

- ✅ **視覚的にスッキリ**: 不要な水平線を削除
- ✅ **自然な間隔**: h2タイトルの自然なマージンでカテゴリが区別される
- ✅ **読みやすさ向上**: カテゴリ間の境界がより自然で読みやすい
- ✅ **モダンなデザイン**: 過度な境界線のないクリーンなレイアウト

## 影響範囲

- 📱 **メインページ**: index.html の表示改善
- 📁 **アーカイブページ**: 全アーカイブページの表示改善
- 📝 **Markdownページ**: 影響なし（もともと水平線なし）

## テスト確認

- ✅ カテゴリ間の水平線が削除されている
- ✅ カテゴリの区別は h2 タイトルで適切に行われている
- ✅ 全体的な見た目がスッキリしている
- ✅ 他の要素に影響がない