### PR TITLE
📱 記事タイトルのはみ出し問題修正とモバイル表示改善 (#68)

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -71,6 +71,7 @@ a:hover {
     display: flex;
     align-items: flex-start;
     gap: 15px;
+    min-width: 0; /* flex子要素の縮小を許可 */
 }
 
 .card-image {
@@ -81,6 +82,7 @@ a:hover {
 
 .card-text {
     flex: 1;
+    min-width: 0; /* テキストオーバーフローを防ぐ */
 }
 
 .card-title {
@@ -89,6 +91,9 @@ a:hover {
     line-height: 1.4;
     color: #0969da;
     font-weight: 600;
+    word-break: break-word;
+    overflow-wrap: break-word;
+    hyphens: auto;
 }
 
 .card-source {


### PR DESCRIPTION
Fixes #68

## 問題の解決
モバイル表示時に長い記事タイトルがカードブロックからはみ出す問題を解決しました。

## 修正内容

### 🔧 CSS改善項目

#### 1. タイトル改行制御
```css
.card-title {
    word-break: break-word;        /* 長い単語の適切な改行 */
    overflow-wrap: break-word;     /* 単語境界での折り返し */
    hyphens: auto;                 /* 自動ハイフネーション */
}
```

#### 2. Flexレイアウト最適化
```css
.card-content {
    min-width: 0;  /* flex子要素の縮小を許可 */
}

.card-text {
    min-width: 0;  /* テキストオーバーフローを防ぐ */
}
```

## Before / After

### Before 🚫
```
┌─────────────────────────┐
│ VeryLongTitleThatOverfl→│ ← はみ出し
│ows the card boundary   │
│                         │
└─────────────────────────┘
```

### After ✅
```
┌─────────────────────────┐
│ VeryLongTitleThatOver-  │ ← 適切な改行
│ flows the card boundary │
│                         │
└─────────────────────────┘
```

## テスト結果

### ✅ 検証パターン
- **通常タイトル**: そのまま正常表示
- **長い日本語**: 適切な位置で改行
- **長い英単語**: word-breakで分割
- **混在テキスト**: 言語に応じた最適改行

### ✅ 対応デバイス
- スマートフォン (320px〜)
- タブレット (768px〜)  
- デスクトップ (1024px〜)

## 技術的詳細

### CSS プロパティの役割
- **word-break: break-word**: 単語内での改行を許可
- **overflow-wrap: break-word**: コンテナに収まらない場合の改行
- **hyphens: auto**: ブラウザによる自動ハイフネーション
- **min-width: 0**: flexアイテムの最小幅制約を解除

### レスポンシブ対応
- すべてのブレークポイントで適用
- 既存デザインとの完全な互換性
- パフォーマンスへの影響なし

## Issue #21との関係
これは Issue #21 (📱 レスポンシブデザイン強化) の部分的な先行対応です：
- 今回: タイトルはみ出し問題の緊急修正
- 今後: 包括的なモバイル最適化の実装

## 改善効果

✅ **ユーザビリティ**: 読みやすさの大幅向上  
✅ **レイアウト安定性**: カード表示の一貫性確保  
✅ **モバイル対応**: 小画面での快適な閲覧  
✅ **アクセシビリティ**: 長いタイトルの可読性向上  

🤖 Generated with [Claude Code](https://claude.ai/code)