### PR TITLE
✨ 記事プレビュー機能（ホバー・タップ）を実装 (#22)

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -358,3 +358,227 @@ a:hover {
     }
 }
 
+/* =================================================
+   プレビュー機能
+   ================================================= */
+
+/* カードにホバー可能であることを示す */
+.card {
+    position: relative;
+    cursor: pointer;
+}
+
+/* プレビューポップアップの基本スタイル */
+.card-preview {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: white;
+    border: 1px solid #e1e5e9;
+    border-radius: 8px;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.15);
+    z-index: 1000;
+    margin-top: 8px;
+    opacity: 0;
+    transform: translateY(-10px);
+    transition: all 0.3s ease;
+    pointer-events: none;
+    max-width: 400px;
+}
+
+/* プレビュー表示時の状態 */
+.card-preview.show {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+}
+
+/* プレビューコンテンツ */
+.preview-content {
+    padding: 16px;
+}
+
+/* プレビューヘッダー */
+.preview-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 12px;
+}
+
+.preview-title {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: #1f2328;
+    line-height: 1.4;
+    flex: 1;
+    padding-right: 8px;
+}
+
+.preview-close {
+    background: none;
+    border: none;
+    font-size: 20px;
+    color: #656d76;
+    cursor: pointer;
+    padding: 0;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    transition: background-color 0.2s ease;
+    flex-shrink: 0;
+}
+
+.preview-close:hover {
+    background-color: #f6f8fa;
+    color: #1f2328;
+}
+
+/* プレビューメタ情報 */
+.preview-meta {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 12px;
+    font-size: 12px;
+    color: #656d76;
+    flex-wrap: wrap;
+}
+
+.preview-source {
+    font-weight: 500;
+    color: #0969da;
+}
+
+.preview-date {
+    color: #656d76;
+}
+
+.preview-read-time {
+    color: #656d76;
+}
+
+/* プレビュー説明文 */
+.preview-description {
+    font-size: 14px;
+    line-height: 1.5;
+    color: #333;
+    margin-bottom: 16px;
+    max-height: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* プレビューアクション */
+.preview-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.preview-read-btn {
+    background-color: #0969da;
+    color: white;
+    text-decoration: none;
+    padding: 6px 12px;
+    border-radius: 4px;
+    font-size: 13px;
+    font-weight: 500;
+    transition: background-color 0.2s ease;
+    display: inline-flex;
+    align-items: center;
+}
+
+.preview-read-btn:hover {
+    background-color: #0860ca;
+    color: white;
+    text-decoration: none;
+}
+
+/* ローディング状態 */
+.preview-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    color: #656d76;
+    font-size: 14px;
+}
+
+.preview-loading::before {
+    content: "";
+    width: 16px;
+    height: 16px;
+    border: 2px solid #f0f0f0;
+    border-top: 2px solid #0969da;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin-right: 8px;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+/* プレビューのレスポンシブ対応 */
+@media (max-width: 768px) {
+    .card-preview {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        margin-top: 0;
+        max-width: 90vw;
+        max-height: 80vh;
+        overflow-y: auto;
+        z-index: 2000;
+    }
+    
+    .card-preview.show {
+        transform: translate(-50%, -50%);
+    }
+    
+    /* モバイル用のオーバーレイ背景 */
+    .preview-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0,0,0,0.5);
+        z-index: 1999;
+        opacity: 0;
+        transition: opacity 0.3s ease;
+        pointer-events: none;
+    }
+    
+    .preview-overlay.show {
+        opacity: 1;
+        pointer-events: auto;
+    }
+}
+
+@media (max-width: 480px) {
+    .card-preview {
+        max-width: 95vw;
+        max-height: 85vh;
+    }
+    
+    .preview-content {
+        padding: 14px;
+    }
+    
+    .preview-title {
+        font-size: 15px;
+    }
+    
+    .preview-description {
+        font-size: 13px;
+        max-height: 100px;
+    }
+}
+

--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -1,0 +1,228 @@
+/**
+ * 記事プレビュー機能
+ * デスクトップ：ホバー時にプレビュー表示
+ * モバイル：タップ時にプレビュー表示
+ */
+
+class ArticlePreview {
+    constructor() {
+        this.activePreview = null;
+        this.isMobile = window.innerWidth <= 768;
+        this.previewTimeout = null;
+        this.overlay = null;
+        
+        this.init();
+    }
+    
+    init() {
+        this.createOverlay();
+        this.attachEventListeners();
+        this.handleResize();
+    }
+    
+    createOverlay() {
+        // モバイル用のオーバーレイ背景を作成
+        this.overlay = document.createElement('div');
+        this.overlay.className = 'preview-overlay';
+        this.overlay.addEventListener('click', () => this.hideActivePreview());
+        document.body.appendChild(this.overlay);
+    }
+    
+    attachEventListeners() {
+        const cards = document.querySelectorAll('.card');
+        
+        cards.forEach(card => {
+            const preview = card.querySelector('.card-preview');
+            if (!preview) return;
+            
+            if (this.isMobile) {
+                // モバイル：タップイベント
+                card.addEventListener('click', (e) => this.handleMobileClick(e, card, preview));
+            } else {
+                // デスクトップ：ホバーイベント
+                card.addEventListener('mouseenter', (e) => {
+                    // タイトルリンクのクリック時はプレビューを表示しない
+                    if (e.target.tagName === 'A') return;
+                    this.handleDesktopHover(card, preview);
+                });
+                card.addEventListener('mouseleave', (e) => this.handleDesktopLeave(card, preview));
+            }
+        });
+        
+        // ESCキーでプレビューを閉じる
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') {
+                this.hideActivePreview();
+            }
+        });
+    }
+    
+    handleMobileClick(event, card, preview) {
+        // リンククリック時はプレビューではなく記事に移動
+        if (event.target.tagName === 'A' || event.target.closest('a')) {
+            return; // デフォルトのリンク動作を許可
+        }
+        
+        event.preventDefault();
+        
+        // 既にプレビューが表示されている場合は閉じる
+        if (preview.classList.contains('show')) {
+            this.hidePreview(preview);
+            return;
+        }
+        
+        // 他のプレビューを閉じる
+        this.hideActivePreview();
+        
+        // プレビューを表示
+        this.showPreview(preview);
+        this.activePreview = preview;
+    }
+    
+    handleDesktopHover(card, preview) {
+        // 遅延表示でちらつきを防止
+        this.previewTimeout = setTimeout(() => {
+            this.hideActivePreview();
+            this.showPreview(preview);
+            this.activePreview = preview;
+            
+            // プレビュー位置を調整
+            this.adjustPreviewPosition(card, preview);
+        }, 300);
+    }
+    
+    handleDesktopLeave(card, preview) {
+        // ホバー遅延をクリア
+        if (this.previewTimeout) {
+            clearTimeout(this.previewTimeout);
+            this.previewTimeout = null;
+        }
+        
+        // プレビューが表示されている場合は少し遅延して閉じる
+        setTimeout(() => {
+            if (this.activePreview === preview && !this.isHoveringPreview(preview)) {
+                this.hidePreview(preview);
+                this.activePreview = null;
+            }
+        }, 200);
+    }
+    
+    showPreview(preview) {
+        preview.style.display = 'block';
+        
+        // レイアウト計算を強制実行
+        preview.offsetHeight;
+        
+        preview.classList.add('show');
+        
+        if (this.isMobile) {
+            this.overlay.classList.add('show');
+            document.body.style.overflow = 'hidden';
+        }
+    }
+    
+    hidePreview(preview) {
+        preview.classList.remove('show');
+        
+        setTimeout(() => {
+            preview.style.display = 'none';
+        }, 300);
+        
+        if (this.isMobile) {
+            this.overlay.classList.remove('show');
+            document.body.style.overflow = '';
+        }
+    }
+    
+    hideActivePreview() {
+        if (this.activePreview) {
+            this.hidePreview(this.activePreview);
+            this.activePreview = null;
+        }
+    }
+    
+    adjustPreviewPosition(card, preview) {
+        if (this.isMobile) return;
+        
+        const cardRect = card.getBoundingClientRect();
+        const previewRect = preview.getBoundingClientRect();
+        const viewportWidth = window.innerWidth;
+        const viewportHeight = window.innerHeight;
+        
+        // 横方向の調整
+        if (cardRect.right + previewRect.width > viewportWidth - 20) {
+            preview.style.left = 'auto';
+            preview.style.right = '0';
+        } else {
+            preview.style.left = '0';
+            preview.style.right = 'auto';
+        }
+        
+        // 縦方向の調整（画面下端を超える場合）
+        if (cardRect.bottom + previewRect.height > viewportHeight - 20) {
+            preview.style.top = 'auto';
+            preview.style.bottom = '100%';
+            preview.style.marginTop = '0';
+            preview.style.marginBottom = '8px';
+        } else {
+            preview.style.top = '100%';
+            preview.style.bottom = 'auto';
+            preview.style.marginTop = '8px';
+            preview.style.marginBottom = '0';
+        }
+    }
+    
+    isHoveringPreview(preview) {
+        const previewRect = preview.getBoundingClientRect();
+        const mouseX = event.clientX;
+        const mouseY = event.clientY;
+        
+        return mouseX >= previewRect.left && mouseX <= previewRect.right &&
+               mouseY >= previewRect.top && mouseY <= previewRect.bottom;
+    }
+    
+    handleResize() {
+        window.addEventListener('resize', () => {
+            const wasMobile = this.isMobile;
+            this.isMobile = window.innerWidth <= 768;
+            
+            // モバイル⇔デスクトップ切り替え時にイベントリスナーを再設定
+            if (wasMobile !== this.isMobile) {
+                this.hideActivePreview();
+                this.removeEventListeners();
+                this.attachEventListeners();
+            }
+        });
+    }
+    
+    removeEventListeners() {
+        const cards = document.querySelectorAll('.card');
+        cards.forEach(card => {
+            card.replaceWith(card.cloneNode(true));
+        });
+    }
+}
+
+// プレビューを閉じるグローバル関数（HTMLから呼び出し用）
+function hidePreview(event, cardId) {
+    event.preventDefault();
+    event.stopPropagation();
+    
+    const preview = document.getElementById(`preview-${cardId}`);
+    if (preview && window.articlePreview) {
+        window.articlePreview.hidePreview(preview);
+        window.articlePreview.activePreview = null;
+    }
+}
+
+// DOM読み込み完了後に初期化
+document.addEventListener('DOMContentLoaded', () => {
+    window.articlePreview = new ArticlePreview();
+});
+
+// ページ表示時にも初期化（ブラウザバック対応）
+window.addEventListener('pageshow', () => {
+    if (!window.articlePreview) {
+        window.articlePreview = new ArticlePreview();
+    }
+});

--- a/assets/templates/card.html
+++ b/assets/templates/card.html
@@ -1,9 +1,30 @@
-<a href="{{link}}" class="card">
+<div class="card" data-preview-link="{{link}}" data-preview-title="{{title}}" data-preview-source="{{feed_name}}" data-preview-description="{{description}}" data-preview-published="{{published_date}}">
     <div class="card-content">
         {{thumbnail}}
         <div class="card-text">
-            <h4 class="card-title">{{title}}</h4>
-            <p class="card-source">{{feed_name}}</p>
+            <h4 class="card-title">
+                <a href="{{link}}" target="_blank">{{title}}</a>
+            </h4>
+            <p class="card-source">{{feed_name}} • {{relative_date}}</p>
         </div>
     </div>
-</a>
+    <div class="card-preview" id="preview-{{card_id}}" style="display: none;">
+        <div class="preview-content">
+            <div class="preview-header">
+                <h5 class="preview-title">{{title}}</h5>
+                <button class="preview-close" onclick="hidePreview(event, '{{card_id}}')">&times;</button>
+            </div>
+            <div class="preview-meta">
+                <span class="preview-source">{{feed_name}}</span>
+                <span class="preview-date">{{relative_date}}</span>
+                <span class="preview-read-time">{{read_time}}</span>
+            </div>
+            <div class="preview-description">
+                {{description}}
+            </div>
+            <div class="preview-actions">
+                <a href="{{link}}" class="preview-read-btn" target="_blank">記事を読む</a>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Closes #22

## 実装内容
- **デスクトップ**: マウスホバーで記事プレビュー表示（300ms遅延）
- **モバイル**: タップで記事プレビュー表示（オーバーレイ付き）
- **プレビュー情報**: 記事概要、相対日付（「1時間前」など）、推定読時間を表示
- **位置調整**: プレビューポップアップが画面外に出ない自動調整機能
- **アニメーション**: スムーズなフェード効果とスライドアニメーション
- **アクセシビリティ**: ESCキーでプレビューを閉じる機能

## 技術的改善
- **HTMLテンプレート構造最適化**: `<a>`タグの入れ子問題を解決し、記事タイトルのみリンク化
- **新テンプレートシステム活用**: メタ情報（読時間・相対日付）の自動生成機能追加
- **レスポンシブ対応**: デスクトップ（ホバー）・モバイル（タップ・オーバーレイ）の適応的UI
- **パフォーマンス**: DOM要素の効率的な検索とイベント管理

## 主要ファイル変更
- `assets/css/main.css`: プレビュー機能用CSSスタイル（227行追加）
- `assets/js/preview.js`: プレビュー機能のJavaScript（新規作成）
- `assets/templates/card.html`: プレビュー対応HTMLテンプレート
- `src/templates/template_manager.py`: メタ情報拡充機能
- `fetch_news.py`: 新テンプレートシステム対応

## テスト方法
1. 記事カードにマウスホバーしてプレビュー表示を確認
2. 記事タイトルクリックで正常に記事ページに移動することを確認
3. モバイルサイズでタップ時のプレビュー表示を確認
4. プレビューの×ボタンとESCキーでの閉じる動作を確認

🤖 Generated with [Claude Code](https://claude.ai/code)