### PR TITLE
🐛 Xロゴが404エラーで表示されない問題を修正 (#72)

### DIFF
--- a/src/config/archive_config.py
+++ b/src/config/archive_config.py
@@ -27,7 +27,7 @@ class SiteConfig:
     OG_IMAGE_FILENAME: str = "assets/images/OGP.png"
     
     # X(Twitter) 設定
-    X_LOGO_PATH: str = "assets/x-logo/logo-white.png"
+    X_LOGO_PATH: str = "assets/images/x-logo/logo-white.png"
     X_HASHTAGS: str = "techhunter"
     
     def __post_init__(self):

--- a/src/templates/template_manager.py
+++ b/src/templates/template_manager.py
@@ -313,7 +313,7 @@ class ContentStructure:
         """完全なHTMLページを構築"""
         # X logo pathのデフォルト設定
         if x_logo_path is None:
-            x_logo_path = "../../assets/x-logo/logo-white.png" if is_archive else "assets/x-logo/logo-white.png"
+            x_logo_path = "../../assets/images/x-logo/logo-white.png" if is_archive else "assets/images/x-logo/logo-white.png"
         
         head_section = self.template_manager.get_html_head(title, date_str, is_archive)
         css_section = self.template_manager.get_css_link(is_archive)


### PR DESCRIPTION
Fixes #72

## 問題の概要
本番環境でXシェアボタンのロゴが404エラーで表示されていませんでした。

## 原因
Issue #62でディレクトリ構造を変更した際に、Xロゴのファイルパス更新が漏れていました：
- **実際のファイル位置**: `assets/images/x-logo/logo-white.png`
- **コード内参照パス**: `assets/x-logo/logo-white.png` ❌

## 修正内容
### 📁 ファイルパス修正
- `src/config/archive_config.py`: `X_LOGO_PATH`を正しいパスに修正
- `src/templates/template_manager.py`: `x_logo_path`を正しいパスに修正

### 🔧 対象箇所
- メインページ: `assets/images/x-logo/logo-white.png`
- アーカイブページ: `../../assets/images/x-logo/logo-white.png`

## 反映タイミング
次回の自動更新時（毎日JST 7:00のGitHub Actions実行時）に新しいHTMLが生成され、修正が反映されます。

## 動作確認
修正後は以下が正常に動作します：
- [x] メインページでXロゴが表示される
- [x] アーカイブページでXロゴが表示される
- [x] 404エラーが発生しない

🤖 Generated with [Claude Code](https://claude.ai/code)