### PR TITLE
Xシェアリンクのアーカイブページ対応修正 (Issue #77)

### DIFF
--- a/src/templates/template_manager.py
+++ b/src/templates/template_manager.py
@@ -177,7 +177,9 @@ class TemplateManager:
         # アーカイブページの場合はURLを調整
         canonical_url = site_url
         if is_archive:
-            canonical_url = f"{site_url}archives/{date_str.replace('-', '/')}/{date_str}.html"
+            date_obj = datetime.strptime(date_str, '%Y-%m-%d')
+            archive_path = f"{date_obj.year}/{date_obj.month:02d}"
+            canonical_url = f"{site_url}archives/{archive_path}/{date_str}.html"
         
         return f"""<!DOCTYPE html>
 <html lang="ja">
@@ -213,7 +215,9 @@ class TemplateManager:
         hashtags = self.site_config.X_HASHTAGS
         
         if is_archive:
-            tweet_url = f"https://twitter.com/intent/tweet?text=👨‍💻 今日のテックニュース ({date_str}) をチェック！&url={site_url}archives/{date_str.replace('-', '/')}/{date_str}.html&hashtags={hashtags}"
+            date_obj = datetime.strptime(date_str, '%Y-%m-%d')
+            archive_path = f"{date_obj.year}/{date_obj.month:02d}"
+            tweet_url = f"https://twitter.com/intent/tweet?text=👨‍💻 今日のテックニュース ({date_str}) をチェック！&url={site_url}archives/{archive_path}/{date_str}.html&hashtags={hashtags}"
             archive_link = "../index.html"
             archive_text = "アーカイブ一覧"
         else:


### PR DESCRIPTION
## 概要
アーカイブページでのXシェアリンクが正しいURL形式で生成されるように修正しました。

## 問題
- アーカイブページでのXシェアリンクのURL生成ロジックに不備があった
- `date_str.replace('-', '/')` による単純な文字列置換では、正しいディレクトリ構造 (`YYYY/MM`) に対応できていなかった
- 結果として、アーカイブページからのXシェアで不正なURLが生成されていた

## 修正内容

### 🔧 変更ファイル
- `src/templates/template_manager.py`

### ⚡ 主な変更点

#### 1. OGPメタタグのcanonical_url生成の改善
**修正前:**
```python
canonical_url = f"{site_url}archives/{date_str.replace('-', '/')}/{date_str}.html"
```

**修正後:**
```python
date_obj = datetime.strptime(date_str, '%Y-%m-%d')
archive_path = f"{date_obj.year}/{date_obj.month:02d}"
canonical_url = f"{site_url}archives/{archive_path}/{date_str}.html"
```

#### 2. Xシェアリンクのtweet_url生成の改善
**修正前:**
```python
tweet_url = f"https://twitter.com/intent/tweet?text=👨‍💻 今日のテックニュース ({date_str}) をチェック！&url={site_url}archives/{date_str.replace('-', '/')}/{date_str}.html&hashtags={hashtags}"
```

**修正後:**
```python
date_obj = datetime.strptime(date_str, '%Y-%m-%d')
archive_path = f"{date_obj.year}/{date_obj.month:02d}"
tweet_url = f"https://twitter.com/intent/tweet?text=👨‍💻 今日のテックニュース ({date_str}) をチェック！&url={site_url}archives/{archive_path}/{date_str}.html&hashtags={hashtags}"
```

## 技術的詳細

### 改善された点
1. **正確な日付パース**: `datetime.strptime()` を使用して日付文字列を適切にパース
2. **適切なパス生成**: `date_obj.month:02d` でゼロパディングを確実に実行
3. **コードの可読性向上**: 処理の意図が明確になり、保守性が向上

### URL生成例
- **日付**: `2025-07-13`
- **生成されるパス**: `2025/07`
- **最終URL**: `https://unsolublesugar.github.io/daily-tech-news/archives/2025/07/2025-07-13.html`

## テスト状況
- [x] アーカイブページでのOGPメタタグ生成確認
- [x] Xシェアリンクの正しいURL生成確認
- [x] 既存機能への影響がないことを確認

## 影響範囲
- **対象**: アーカイブページのみ
- **影響度**: 低（既存の機能に破壊的変更なし）
- **互換性**: 完全に後方互換

## チェックリスト
- [x] コードレビュー完了
- [x] 修正がブランチにコミット済み
- [x] 関連Issueを正しく解決している
- [x] ドキュメントの更新は不要（内部実装の改善のため）

## 関連Issue
- Fixes #77 
