### PR TITLE
📚 UI要素復旧: RSSフィードメッセージとタイトル表示の統一 (#76)

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -582,3 +582,82 @@ a:hover {
     }
 }
 
+/* RSSカードスタイル */
+.rss-card {
+    background: #f8f9fa;
+    border: 1px solid #e9ecef;
+    border-radius: 12px;
+    margin: 24px 0;
+    padding: 20px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    transition: box-shadow 0.3s ease;
+}
+
+.rss-card:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.rss-card-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 16px;
+}
+
+.rss-card-icon {
+    font-size: 48px;
+    flex-shrink: 0;
+}
+
+.rss-card-text h3 {
+    margin: 0 0 8px 0;
+    font-size: 20px;
+    color: #333;
+    font-weight: 600;
+}
+
+.rss-card-text p {
+    margin: 0 0 12px 0;
+    color: #666;
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.rss-link {
+    display: inline-block;
+    background: #007bff;
+    color: white !important;
+    text-decoration: none;
+    padding: 8px 16px;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 500;
+    transition: background-color 0.3s ease;
+}
+
+.rss-link:hover {
+    background: #0056b3;
+    text-decoration: none;
+}
+
+/* モバイル対応 */
+@media (max-width: 768px) {
+    .rss-card {
+        margin: 16px 0;
+        padding: 16px;
+    }
+    
+    .rss-card-content {
+        gap: 12px;
+    }
+    
+    .rss-card-icon {
+        font-size: 36px;
+    }
+    
+    .rss-card-text h3 {
+        font-size: 18px;
+    }
+}
+

--- a/fetch_news.py
+++ b/fetch_news.py
@@ -478,7 +478,7 @@ def generate_html(all_entries, feed_info, date_str, thumbnails=None):
                 entries_html += card_html
     
     # 完全なHTMLページを構築
-    title = f"👨‍💻 今日のテックニュース ({date_str})"
+    title = f"今日のテックニュース ({date_str})"
     html_content = content_structure.build_html_page(
         title=title,
         date_str=date_str,
@@ -490,7 +490,7 @@ def generate_html(all_entries, feed_info, date_str, thumbnails=None):
 
 def generate_markdown(all_entries, feed_info, date_str):
     """取得したエントリーからMarkdownコンテンツを生成する"""
-    markdown = f"# 👨‍💻 今日のテックニュース ({date_str})\n\n"
+    markdown = f"# 今日のテックニュース ({date_str})\n\n"
     markdown += """📚 [過去のニュースを見る](archives/index.md) | 🎨 [カード表示版を見る](https://unsolublesugar.github.io/daily-tech-news/) | 📡 [RSSフィードを購読](https://unsolublesugar.github.io/daily-tech-news/rss.xml)
 
 日本の主要な技術系メディアの最新人気エントリーをお届けします。
@@ -533,7 +533,7 @@ https://unsolublesugar.github.io/daily-tech-news/
 
 def generate_archive_markdown(all_entries, feed_info, date_str):
     """アーカイブ用のMarkdownコンテンツを生成する（相対パス修正版）"""
-    markdown = f"# 👨‍💻 今日のテックニュース ({date_str})\n\n"
+    markdown = f"# 今日のテックニュース ({date_str})\n\n"
     markdown += """📚 [過去のニュースを見る](../../index.md) | 🎨 [カード表示版を見る](https://unsolublesugar.github.io/daily-tech-news/) | 📡 [RSSフィードを購読](https://unsolublesugar.github.io/daily-tech-news/rss.xml)
 
 日本の主要な技術系メディアの最新人気エントリーをお届けします。
@@ -598,7 +598,7 @@ def generate_archive_html(all_entries, feed_info, date_str, thumbnails=None):
                 entries_html += card_html
     
     # アーカイブ用HTMLページを構築
-    title = f"👨‍💻 今日のテックニュース ({date_str})"
+    title = f"今日のテックニュース ({date_str})"
     html_content = content_structure.build_html_page(
         title=title,
         date_str=date_str,

--- a/fetch_news.py
+++ b/fetch_news.py
@@ -478,7 +478,7 @@ def generate_html(all_entries, feed_info, date_str, thumbnails=None):
                 entries_html += card_html
     
     # 完全なHTMLページを構築
-    title = f"今日のテックニュース ({date_str})"
+    title = f"👨‍💻 今日のテックニュース ({date_str})"
     html_content = content_structure.build_html_page(
         title=title,
         date_str=date_str,
@@ -598,7 +598,7 @@ def generate_archive_html(all_entries, feed_info, date_str, thumbnails=None):
                 entries_html += card_html
     
     # アーカイブ用HTMLページを構築
-    title = f"今日のテックニュース ({date_str})"
+    title = f"👨‍💻 今日のテックニュース ({date_str})"
     html_content = content_structure.build_html_page(
         title=title,
         date_str=date_str,

--- a/src/templates/template_manager.py
+++ b/src/templates/template_manager.py
@@ -241,7 +241,18 @@ class TemplateManager:
             main_page_link = '<p><a href="../../index.html" class="nav-button">🏠 メインページに戻る</a></p>\n        '
             rss_link = f'<p>📡 <a href="{site_url}rss.xml">RSSフィードを購読</a></p>\n        '
         else:
-            rss_link = f'<p>📡 <a href="{site_url}rss.xml">RSSフィード配信中です</a></p>\n        '
+            # メインページ用のカード表示デザイン
+            rss_link = f'''<div class="rss-card">
+        <div class="rss-card-content">
+            <div class="rss-card-icon">📡</div>
+            <div class="rss-card-text">
+                <h3>RSSフィード配信中</h3>
+                <p>お使いのRSSリーダーで購読してください</p>
+                <a href="{site_url}rss.xml" class="rss-link" target="_blank">RSSフィードを購読する</a>
+            </div>
+        </div>
+    </div>
+    '''
         
         template = self.load_template('footer.html')
         return self.render_template(

--- a/src/templates/template_manager.py
+++ b/src/templates/template_manager.py
@@ -240,6 +240,8 @@ class TemplateManager:
         if is_archive:
             main_page_link = '<p><a href="../../index.html" class="nav-button">🏠 メインページに戻る</a></p>\n        '
             rss_link = f'<p>📡 <a href="{site_url}rss.xml">RSSフィードを購読</a></p>\n        '
+        else:
+            rss_link = f'<p>📡 <a href="{site_url}rss.xml">RSSフィード配信中です</a></p>\n        '
         
         template = self.load_template('footer.html')
         return self.render_template(


### PR DESCRIPTION
Closes #76

## 変更内容
- トップページフッターのRSSフィード配信メッセージを復旧
- タイトル表示の統一（ページタイトルから絵文字除去、シェア時は絵文字保持）
- template_manager.pyでメインページ用のRSSリンク生成ロジックを修正
- fetch_news.pyでHTML/Markdownタイトルから👨‍💻絵文字を除去

## 修正後の動作
- **ページタイトル**: 「今日のテックニュース (2025-07-13)」（絵文字なし）
- **Twitterシェア/OGP**: 「👨‍💻 今日のテックニュース (2025-07-13)」（絵文字あり）
- **RSSメッセージ**: フッター内に詳細なRSSフィード情報を表示
- **RSSリンク**: クリック可能でユーザビリティ向上

## 変更理由
- ユーザーがRSSフィード購読方法を見つけやすくするため
- 過去に存在していたRSSメッセージを復旧するため
- ページタイトルをシンプルにしつつ、SNSシェア時は視認性を保持

## テスト方法
- トップページのフッター部分にRSSメッセージが表示されることを確認
- ページタイトルに絵文字が含まれていないことを確認
- TwitterシェアボタンとOGP表示では絵文字付きタイトルが使用されることを確認
- RSSリンクが正常に機能することを確認

## 関連Issue
- Issue #76: トップページUI要素の復旧