### PR TITLE
⏱️ プレビュー読時間表示を削除 (#82)

### DIFF
--- a/assets/templates/card.html
+++ b/assets/templates/card.html
@@ -17,7 +17,6 @@
             <div class="preview-meta">
                 <span class="preview-source">{{feed_name}}</span>
                 <span class="preview-date">{{relative_date}}</span>
-                <span class="preview-read-time">{{read_time}}</span>
             </div>
             <div class="preview-description">
                 {{description}}


### PR DESCRIPTION
Closes #82

## 変更内容
- プレビューカードから読時間表示を削除
- template_manager.pyのcalculate_read_time関数呼び出しを除去
- card.htmlテンプレートから読時間表示部分を削除

## 変更理由
- RSSフィードのdescriptionベースでは実際の記事ボリュームと大きく乖離
- 「約1-3分」程度の不正確な情報がユーザーの混乱を招く可能性
- プレビューカードをより簡潔にして正確な情報のみ表示

## 修正後の表示
- プレビューメタ情報：フィード名 + 公開日時のみ
- より簡潔で正確な情報提供
- 将来的にはIssue #23のタグ機能で置き換え予定

## 影響範囲
- プレビューカードの表示内容
- 記事カードのメタ情報部分

## テスト方法
- 記事カードをホバー/タップしてプレビュー表示を確認
- 読時間表示が削除されていることを確認
- フィード名と公開日時は正常に表示されることを確認