### PR TITLE
🐛 プレビュータイトル表示の修正 (#85)

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -681,6 +681,9 @@ a:hover {
 /* プレビューコンテンツ */
 .preview-content {
     padding: 16px;
+    /* プレビューコンテンツ全体の幅制御 */
+    max-width: 100%;
+    box-sizing: border-box;
 }
 
 /* プレビューヘッダー */
@@ -699,6 +702,11 @@ a:hover {
     line-height: 1.4;
     flex: 1;
     padding-right: 8px;
+    /* 長いタイトルの折り返し処理 */
+    word-wrap: break-word;
+    word-break: break-word;
+    overflow-wrap: break-word;
+    white-space: normal;
 }
 
 .preview-close {


### PR DESCRIPTION
Fixes #85

## 変更内容
プレビューダイアログで長いタイトルが枠外に突き抜ける問題を修正

### 修正箇所
- **`.preview-title`**: 長いタイトルの折り返し処理を追加
  - `word-wrap: break-word`
  - `word-break: break-word`
  - `overflow-wrap: break-word`
  - `white-space: normal`

- **`.preview-content`**: 全体の幅制御を改善
  - `max-width: 100%`
  - `box-sizing: border-box`

### 対象の問題記事
- URL: https://dev.classmethod.jp/articles/athena-idc-create-workgroup/
- タイトル: 「IAM Identity Center 認証の Athena ワークグループを作成する際に...」（異常に長いタイトル）

## テスト結果
- ✅ 長いタイトルが適切に折り返される
- ✅ タイトルがダイアログ枠内に収まる
- ✅ ×ボタンの位置が維持される
- ✅ デスクトップ・モバイル両対応

## 影響範囲
- プレビューダイアログのタイトル表示（全ページ）
- 特に長いタイトルを持つ記事のプレビュー表示

🤖 Generated with [Claude Code](https://claude.ai/code)