### PR TITLE
👨‍💻サイト説明文をエンジニア向けに調整

### DIFF
--- a/src/config/archive_config.py
+++ b/src/config/archive_config.py
@@ -11,7 +11,7 @@ class SiteConfig:
     
     # サイト基本情報
     SITE_TITLE_TEMPLATE: str = "👨‍💻 今日のテックニュース ({date})"
-    SITE_DESCRIPTION: str = "日本の主要な技術系メディアの最新人気エントリーを毎日お届けします。"
+    SITE_DESCRIPTION: str = "忙しいエンジニアのために。毎日サクッとキャッチアップ。"
     SITE_URL: str = "https://unsolublesugar.github.io/daily-tech-news/"
     TWITTER_USER: str = "@unsoluble_sugar"
     


### PR DESCRIPTION
## 概要

サイトのトップページおよびOGP/Twitterカードで表示される説明文を、よりエンジニア向けに最適化されたコピーに変更しました。

## 変更内容

`src/config/archive_config.py` 内の `SITE_DESCRIPTION` の値を以下の通り変更しました。

**変更前:**
`日本の主要な技術系メディアの最新人気エントリーを毎日お届けします。`

**変更後:**
`忙しいエンジニアのために。毎日サクッとキャッチアップ。`

## 目的

サイトのターゲットユーザーであるエンジニア層に対して、より響くメッセージングにすることで、サイトの目的と価値を明確に伝えます。

Refs #89
