### PR TITLE
🔧 デスクトップ: カード全体クリックでの記事遷移機能を改善 (#91)

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -649,10 +649,18 @@ a:hover {
    プレビュー機能
    ================================================= */
 
-/* カードにホバー可能であることを示す */
+/* カードにホバー・クリック可能であることを示す */
 .card {
     position: relative;
     cursor: pointer;
+}
+
+/* デスクトップでのカードホバー時の視覚フィードバック */
+@media (min-width: 769px) {
+    .card:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 6px 12px rgba(0,0,0,0.2);
+    }
 }
 
 /* プレビューポップアップの基本スタイル */

--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -36,16 +36,17 @@ class ArticlePreview {
             if (!preview) return;
             
             if (this.isMobile) {
-                // モバイル：タップイベント
+                // モバイル：タップイベント（プレビュー表示）
                 card.addEventListener('click', (e) => this.handleMobileClick(e, card, preview));
             } else {
-                // デスクトップ：ホバーイベント
+                // デスクトップ：ホバーでプレビュー、クリックで記事に遷移
                 card.addEventListener('mouseenter', (e) => {
                     // タイトルリンクのクリック時はプレビューを表示しない
                     if (e.target.tagName === 'A') return;
                     this.handleDesktopHover(card, preview);
                 });
                 card.addEventListener('mouseleave', (e) => this.handleDesktopLeave(card, preview));
+                card.addEventListener('click', (e) => this.handleDesktopClick(e, card));
             }
         });
         
@@ -105,6 +106,20 @@ class ArticlePreview {
                 this.activePreview = null;
             }
         }, 200);
+    }
+    
+    handleDesktopClick(event, card) {
+        // リンククリック時はデフォルトの動作を許可
+        if (event.target.tagName === 'A' || event.target.closest('a')) {
+            return;
+        }
+        
+        // カード全体のクリックで記事に遷移
+        const articleLink = card.querySelector('.card-title a');
+        if (articleLink) {
+            // 新しいタブで記事を開く
+            window.open(articleLink.href, '_blank');
+        }
     }
     
     showPreview(preview) {


### PR DESCRIPTION
Closes #91

## 変更内容
- デスクトップ環境でカード全体をクリックした際の記事遷移機能を追加
- ホバー時はプレビュー表示、クリック時は新しいタブで記事に遷移する仕様に統一
- タイトルリンククリック時は従来通りの動作を維持
- カードホバー時の視覚的フィードバックを追加

## 技術的変更
### JavaScript (`assets/js/preview.js`)
- `handleDesktopClick`関数を追加
- デスクトップ環境でのクリックイベントリスナーを追加
- リンククリック時とカード全体クリック時の動作を適切に分離

### CSS (`assets/css/main.css`) 
- カードホバー時の視覚フィードバック追加
- `transform: translateY(-2px)` と `box-shadow` でユーザビリティ向上

## 動作仕様
- **ホバー**: プレビュー表示（従来通り）
- **カード全体クリック**: 新しいタブで記事に遷移（新機能）
- **タイトルリンククリック**: 記事に遷移（従来通り）
- **モバイル**: タップでプレビュー表示（変更なし）

## テスト方法
1. デスクトップ環境でページを表示
2. カードにホバー → プレビューが表示されることを確認
3. カード全体をクリック → 新しいタブで記事が開くことを確認
4. タイトルリンクをクリック → 従来通り記事に遷移することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)