### PR TITLE
✨ URL重複チェック: PRIORITY_FEEDSベースの優先順位制御 (#102)

### DIFF
--- a/fetch_news.py
+++ b/fetch_news.py
@@ -37,6 +37,12 @@ FEEDS = {
     "O'Reilly Japan - 近刊": "https://www.oreilly.co.jp/catalog/soon.xml"
 }
 
+# 除外するドメインのリスト
+EXCLUDED_DOMAINS = {
+    'anond.hatelabo.jp': 'hatena anonymous diary',
+    'togetter.com': 'togetter'
+}
+
 # 各フィードから取得する記事の件数
 MAX_ENTRIES = 5
 
@@ -147,20 +153,18 @@ class ThumbnailCache:
         if keys_to_remove:
             print(f"Cleaned up {len(keys_to_remove)} old cache entries")
 
-def filter_hatena_anonymous_entries(entries):
-    """はてな匿名ダイアリーの記事を除外する"""
+def filter_entries_by_domain(entries, domain, label):
     filtered_entries = []
     excluded_count = 0
     
     for entry in entries:
-        # リンクURLがはてな匿名ダイアリーかチェック
-        if hasattr(entry, 'link') and 'anond.hatelabo.jp' in entry.link:
+        if hasattr(entry, 'link') and domain in entry.link:
             excluded_count += 1
             continue
         filtered_entries.append(entry)
     
     if excluded_count > 0:
-        print(f"Excluded {excluded_count} hatena anonymous diary entries")
+        print(f"Excluded {excluded_count} {label} entries")
     
     return filtered_entries
 
@@ -1315,9 +1319,10 @@ if __name__ == "__main__":
         print(f"Fetching entries from {name}...")
         entries = fetch_feed_entries(feed_url)
         
-        # はてなブックマークのフィードに対してはてな匿名ダイアリーを除外
-        if name in ["はてなブックマーク - IT（人気）", "はてなブックマーク - IT（新着）"]:
-            entries = filter_hatena_anonymous_entries(entries)
+        for domain, label in EXCLUDED_DOMAINS.items():
+            if domain == 'anond.hatelabo.jp' and name not in ["はてなブックマーク - IT（人気）", "はてなブックマーク - IT（新着）"]:
+                continue
+            entries = filter_entries_by_domain(entries, domain, label)
         
         all_entries[name] = entries
     


### PR DESCRIPTION
Closes #102

## 変更内容
- `deduplicate_urls_across_feeds`関数をPRIORITY_FEEDSの順序に基づいた処理に変更
- 高優先度フィード（Tech Blog Weekly, Zenn, Qiita）が低優先度フィード（はてなブックマーク）より優先されるように修正
- 重複除去統計情報の出力機能を追加（除外された記事のタイトルとURLを表示）
- togetterフィルターの追加でゴシップ記事を除外
- EXCLUDED_DOMAINS定数化で除外ドメイン設定を一元管理
- フィルター機能の共通化でコードの保守性向上

## 変更理由
- QiitaやZennの記事がはてなブックマークからの選出と重複した際に適切な優先順位制御が必要
- PRIORITY_FEEDSの設定が重複チェックに反映されていなかった問題を解決
- togetterの記事は有用性が低くゴシップじみたものが多いため除外
- 除外フィルターの設定を定数化して管理しやすく

## テスト方法
- `python3 fetch_news.py`を実行して重複除去統計が出力されることを確認
- はてなブックマーク系フィードから重複URLが適切に除去されることを確認
- togetterとはてな匿名ダイアリーの記事が除外されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)