### PR TITLE
✨ URL正規化: UTMパラメータ等を除外した正規化URLでの重複検出 (#104)

### DIFF
--- a/fetch_news.py
+++ b/fetch_news.py
@@ -13,6 +13,7 @@ from concurrent.futures import ThreadPoolExecutor
 import concurrent.futures
 import json
 import hashlib
+from urllib.parse import urlparse, urlunparse, urlencode, parse_qsl
 
 # srcディレクトリをPythonパスに追加
 sys.path.append(os.path.join(os.path.dirname(__file__), 'src'))
@@ -152,6 +153,33 @@ class ThumbnailCache:
         
         if keys_to_remove:
             print(f"Cleaned up {len(keys_to_remove)} old cache entries")
+
+_TRACKING_PARAMS = frozenset({
+    "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
+    "ref", "fbclid", "gclid",
+})
+
+def normalize_url(url):
+    """URLを正規化して重複検出の精度を向上させる。
+
+    - トラッキングパラメータ（utm_*、ref、fbclid、gclid）を除去
+    - スキームを https に統一（http -> https）
+    - パス末尾のスラッシュを除去
+    - 元のURLは変更しない（比較用のみ）
+    """
+    if not url:
+        return url
+    try:
+        parsed = urlparse(url)
+        scheme = "https" if parsed.scheme == "http" else parsed.scheme
+        path = parsed.path.rstrip("/") or "/"
+        filtered_query = urlencode(
+            [(k, v) for k, v in parse_qsl(parsed.query)
+             if k.lower() not in _TRACKING_PARAMS]
+        )
+        return urlunparse((scheme, parsed.netloc, path, parsed.params, filtered_query, ""))
+    except Exception:
+        return url
 
 def filter_entries_by_domain(entries, domain, label):
     filtered_entries = []
@@ -359,7 +387,7 @@ def deduplicate_urls_across_feeds(all_entries):
     """フィード間でのURL重複を除去し、補填を行う（PRIORITY_FEEDS順で処理）"""
     seen_urls = set()
     deduplicated_feeds = {}
-    dedup_stats = {"total_removed": 0, "by_feed": {}}
+    dedup_stats = {"total_removed": 0, "norm_caught": 0, "by_feed": {}}
     
     # PRIORITY_FEEDSの順序でフィードを処理
     from src.config.archive_config import DEFAULT_SITE_CONFIG
@@ -379,69 +407,86 @@ def deduplicate_urls_across_feeds(all_entries):
             # イベントフィードかどうかで目標件数を決定
             target_count = 10 if "イベント" in feed_name else 5
             
-            # URL重複除去
+            # URL重複除去（正規化URLで比較）
             unique_entries = []
             removed_count = 0
+            norm_caught_feed = 0
             for entry in entries:
-                if hasattr(entry, 'link') and entry.link not in seen_urls:
-                    seen_urls.add(entry.link)
+                if not hasattr(entry, 'link'):
                     unique_entries.append(entry)
-                    
-                    # 目標件数に達したら終了
+                    continue
+                norm = normalize_url(entry.link)
+                if norm not in seen_urls:
+                    seen_urls.add(norm)
+                    unique_entries.append(entry)
                     if len(unique_entries) >= target_count:
                         break
                 else:
                     removed_count += 1
-                    if hasattr(entry, 'title') and hasattr(entry, 'link'):
+                    if hasattr(entry, 'title'):
                         print(f"重複除去: [{feed_name}] {entry.title}")
                         print(f"  URL: {entry.link}")
-            
+                        if norm != entry.link:
+                            print(f"  正規化URL: {norm}  ← 正規化による検出")
+                            norm_caught_feed += 1
+
             # イベントフィードの場合はさらにイベント重複除去を適用
             if "イベント" in feed_name:
                 unique_entries = deduplicate_events(unique_entries, target_count)
-            
+
             deduplicated_feeds[feed_name] = unique_entries
             dedup_stats["by_feed"][feed_name] = removed_count
             dedup_stats["total_removed"] += removed_count
-    
+            dedup_stats["norm_caught"] += norm_caught_feed
+
     # PRIORITY_FEEDSに含まれていないフィードを処理
     for feed_name, entries in all_entries.items():
         if feed_name not in processed_feeds:
             if not entries:
                 deduplicated_feeds[feed_name] = entries
                 continue
-                
+
             # イベントフィードかどうかで目標件数を決定
             target_count = 10 if "イベント" in feed_name else 5
-            
-            # URL重複除去
+
+            # URL重複除去（正規化URLで比較）
             unique_entries = []
             removed_count = 0
+            norm_caught_feed = 0
             for entry in entries:
-                if hasattr(entry, 'link') and entry.link not in seen_urls:
-                    seen_urls.add(entry.link)
+                if not hasattr(entry, 'link'):
                     unique_entries.append(entry)
-                    
-                    # 目標件数に達したら終了
+                    continue
+                norm = normalize_url(entry.link)
+                if norm not in seen_urls:
+                    seen_urls.add(norm)
+                    unique_entries.append(entry)
                     if len(unique_entries) >= target_count:
                         break
                 else:
                     removed_count += 1
-                    if hasattr(entry, 'title') and hasattr(entry, 'link'):
+                    if hasattr(entry, 'title'):
                         print(f"重複除去: [{feed_name}] {entry.title}")
                         print(f"  URL: {entry.link}")
-            
+                        if norm != entry.link:
+                            print(f"  正規化URL: {norm}  ← 正規化による検出")
+                            norm_caught_feed += 1
+
             # イベントフィードの場合はさらにイベント重複除去を適用
             if "イベント" in feed_name:
                 unique_entries = deduplicate_events(unique_entries, target_count)
-            
+
             deduplicated_feeds[feed_name] = unique_entries
             dedup_stats["by_feed"][feed_name] = removed_count
             dedup_stats["total_removed"] += removed_count
-    
+            dedup_stats["norm_caught"] += norm_caught_feed
+
     # 重複除去統計を出力
     if dedup_stats["total_removed"] > 0:
+        norm_caught = dedup_stats["norm_caught"]
+        exact_caught = dedup_stats["total_removed"] - norm_caught
         print(f"URL重複除去統計: 合計{dedup_stats['total_removed']}件を除去")
+        print(f"  うち正規化による検出: {norm_caught}件 / 完全一致による検出: {exact_caught}件")
         for feed_name, removed_count in dedup_stats["by_feed"].items():
             if removed_count > 0:
                 print(f"  {feed_name}: {removed_count}件")

--- a/src/main.py
+++ b/src/main.py
@@ -16,6 +16,7 @@ from concurrent.futures import ThreadPoolExecutor
 import concurrent.futures
 import json
 import hashlib
+from urllib.parse import urlparse, urlunparse, urlencode, parse_qsl
 
 # 新しいクラス群をインポート
 from config import SiteConfig, PathConfig
@@ -264,34 +265,72 @@ def generate_missing_html_archives():
 # 残りの既存関数群（RSS生成、URL重複除去など）は後方互換性のためそのまま保持
 # これらは元のfetch_news.pyから移植
 
+_TRACKING_PARAMS = frozenset({
+    "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
+    "ref", "fbclid", "gclid",
+})
+
+def normalize_url(url):
+    """URLを正規化して重複検出の精度を向上させる（fetch_news.pyのnormalize_urlと同一）。"""
+    if not url:
+        return url
+    try:
+        parsed = urlparse(url)
+        scheme = "https" if parsed.scheme == "http" else parsed.scheme
+        path = parsed.path.rstrip("/") or "/"
+        filtered_query = urlencode(
+            [(k, v) for k, v in parse_qsl(parsed.query)
+             if k.lower() not in _TRACKING_PARAMS]
+        )
+        return urlunparse((scheme, parsed.netloc, path, parsed.params, filtered_query, ""))
+    except Exception:
+        return url
+
 def remove_url_duplicates(all_entries):
-    """URL重複を除去する関数"""
+    """URL重複を除去する関数（正規化URLで比較）"""
     seen_urls = set()
     deduplicated_entries = {}
-    
+    total_removed = 0
+    norm_caught = 0
+
     # 優先フィードの順序を定義
     priority_feeds = ["Tech Blog Weekly", "Zenn", "Qiita", "はてなブックマーク - IT（人気）"]
-    
+
     # 優先フィードから先に処理
     for feed_name in priority_feeds:
         if feed_name in all_entries:
             unique_entries = []
             for entry in all_entries[feed_name]:
-                if entry.link not in seen_urls:
+                norm = normalize_url(entry.link)
+                if norm not in seen_urls:
                     unique_entries.append(entry)
-                    seen_urls.add(entry.link)
+                    seen_urls.add(norm)
+                else:
+                    total_removed += 1
+                    if norm != entry.link:
+                        norm_caught += 1
             deduplicated_entries[feed_name] = unique_entries
-    
+
     # 残りのフィードを処理
     for feed_name, entries in all_entries.items():
         if feed_name not in priority_feeds:
             unique_entries = []
             for entry in entries:
-                if entry.link not in seen_urls:
+                norm = normalize_url(entry.link)
+                if norm not in seen_urls:
                     unique_entries.append(entry)
-                    seen_urls.add(entry.link)
+                    seen_urls.add(norm)
+                else:
+                    total_removed += 1
+                    if norm != entry.link:
+                        norm_caught += 1
             deduplicated_entries[feed_name] = unique_entries
-    
+
+    if total_removed > 0:
+        exact_caught = total_removed - norm_caught
+        print(f"URL重複除去 (remove_url_duplicates): 合計{total_removed}件を除去")
+        print(f"  うち正規化による検出: {norm_caught}件 / 完全一致による検出: {exact_caught}件")
+
     return deduplicated_entries
 
 


### PR DESCRIPTION
Closes #104

## 変更内容
- `normalize_url()` 関数を追加（`fetch_news.py` / `src/main.py` の両方に定義）
  - `utm_*`・`ref`・`fbclid`・`gclid` 等のトラッキングパラメータを除去
  - `http://` → `https://` のスキーム正規化
  - パス末尾のスラッシュを除去
- `deduplicate_urls_across_feeds`（`fetch_news.py`）を正規化URLで比較するよう更新
- `remove_url_duplicates`（`src/main.py`）を同様に更新
- 統計ログに「正規化による検出件数 / 完全一致による検出件数」の内訳を追加

## 変更理由
同一記事がQiitaフィード（UTMパラメータ付き）とはてなブックマークフィード（パラメータなし）で別記事として扱われ重複選出される問題を解消。

## 設計上のポイント
- `entry.link` は変更しない（出力リンクは元のURLを保全）
- 正規化はあくまで `seen_urls` への追加・検索時のみ使用
- `urllib.parse`（stdlib）のみ使用、新規依存ライブラリなし

## 動作確認
```python
from fetch_news import normalize_url
a = "https://qiita.com/tomada/items/e27292b65f723c4633d9"
b = "https://qiita.com/tomada/items/e27292b65f723c4633d9?utm_campaign=popular_items&utm_medium=feed&utm_source=popular_items"
assert normalize_url(a) == normalize_url(b)  # ✅ 通過
```