### PR TITLE
🐛 修正: プレビュー説明文を内部スクロール可能に (#114)

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -838,8 +838,9 @@ a:hover {
     color: var(--text-color);
     margin-bottom: 16px;
     max-height: 120px;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding-right: 8px;
 }
 
 /* プレビューアクション */


### PR DESCRIPTION
Fixes #114

## 変更内容

- `.preview-description` の `overflow: hidden` を `overflow-y: auto` に変更
- `overscroll-behavior: contain` を追加し、親 `.card-preview` へのスクロールチェーンを抑制
- `padding-right: 8px` を追加し、スクロールバーと本文の重なりを回避
- 機能しない `text-overflow: ellipsis` を削除
- `max-height` は現状維持（PC: 120px / SP: 100px）

## 変更理由

プレビュー内の説明文が長い記事（RSSから取得した最大300文字）で、従来は途中で切れたまま読めなかった。スクロール可能にして全文を閲覧できるようにする。タイトル・メタ情報・「記事を読む」ボタンの固定表示は維持。

## テスト方法

1. `python3 -m http.server` でローカルサーバーを起動し `index.html` を開く
2. **PC（幅769px以上）:** 長い説明文の記事カードにホバー → プレビュー内の説明文エリアをマウスホイールで縦スクロールできることを確認
3. **SP（幅768px以下）:** 同カードをタップ → プレビュー内の説明文エリアをタッチスクロールできることを確認
4. スクロール中にプレビューが勝手に閉じないことを確認
5. 短文記事ではスクロールバーが出ず、従来通りの見た目であることを確認
6. ダーク / ライト両テーマでスクロールバーが視認可能か確認

ローカル環境での動作確認済み。