### PR TITLE
✨ フッター: 運営者リンク先をポートフォリオサイトに変更 (#118)

### DIFF
--- a/assets/templates/footer.html
+++ b/assets/templates/footer.html
@@ -1,4 +1,4 @@
 <div class="footer">
-    {{main_page_link}}{{rss_link}}<p>🚀 運営者: <a href="https://x.com/{{twitter_handle}}" target="_blank" rel="noopener">{{twitter_user}}</a> | 
+    {{main_page_link}}{{rss_link}}<p>🚀 <a href="https://unsolublesugar.github.io/portfolio/" target="_blank" rel="noopener">{{twitter_user}}</a> |
     📁 <a href="https://github.com/unsolublesugar/daily-tech-news" target="_blank" rel="noopener">GitHub Repository</a></p>
 </div>

--- a/fetch_news.py
+++ b/fetch_news.py
@@ -1098,7 +1098,7 @@ def generate_missing_html_archives():
                     html_content += """
     <div class="footer">
         <p>📡 <a href="{DEFAULT_SITE_CONFIG.rss_url}">RSSフィードを購読</a></p>
-        <p>🚀 運営者: <a href="{DEFAULT_SITE_CONFIG.profile_url}" target="_blank" rel="noopener">{DEFAULT_SITE_CONFIG.profile_display_name}</a> | 
+        <p>🚀 <a href="https://unsolublesugar.github.io/portfolio/" target="_blank" rel="noopener">{DEFAULT_SITE_CONFIG.profile_display_name}</a> |
         📁 <a href="{DEFAULT_SITE_CONFIG.github_repo_url}" target="_blank" rel="noopener">GitHub Repository</a></p>
     </div>
 </body>

--- a/index.html
+++ b/index.html
@@ -2326,7 +2326,7 @@
             </div>
         </div>
     </div>
-    <p>🚀 運営者: <a href="https://x.com/unsoluble_sugar" target="_blank" rel="noopener">@unsoluble_sugar</a> | 
+    <p>🚀 <a href="https://unsolublesugar.github.io/portfolio/" target="_blank" rel="noopener">@unsoluble_sugar</a> |
     📁 <a href="https://github.com/unsolublesugar/daily-tech-news" target="_blank" rel="noopener">GitHub Repository</a></p>
 </div>
     <script src="assets/js/preview.js"></script>


### PR DESCRIPTION
Closes #118

## 変更内容
- フッターの `🚀 運営者: ` プレフィックスを削除
- `@unsoluble_sugar` のリンク先を X アカウントから作者ポートフォリオサイト (<https://unsolublesugar.github.io/portfolio/>) に変更
- 対象ファイル:
  - `assets/templates/footer.html`（メインのフッターテンプレート）
  - `fetch_news.py`（レガシースクリプトの同等フッター生成ブロック）
  - `index.html`（現行の出力ファイル）

## 変更理由
最近公開した作者ポートフォリオサイトへ導線を流すため、X アカウントリンクから差し替える。

## 対象外
- `archives/` 配下の過去分 HTML は置換しない（過去の公開時点のメタ情報として保持）

## テスト方法
- [x] ローカルで index.html をブラウザ表示し、フッター表記が意図どおり（「運営者:」非表示・ポートフォリオへ遷移）であることを確認
- [ ] PR マージ後、GitHub Pages 反映後にフッターリンクがポートフォリオサイトに遷移することを確認