### PR TITLE
🔧 GitHub Actions を Node.js 24 対応版に更新 (#120)

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.9'
 
     - name: Cache thumbnail data
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: thumbnail_cache.json
         key: thumbnail-cache-${{ runner.os }}-${{ hashFiles('fetch_news.py', 'requirements.txt') }}

--- a/.github/workflows/test-branch.yml
+++ b/.github/workflows/test-branch.yml
@@ -22,10 +22,10 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
-      
+      uses: actions/checkout@v6
+
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.9'
         


### PR DESCRIPTION
Fixes #120

## 変更内容
| アクション | 変更前 | 変更後 |
|---|---|---|
| `actions/checkout` | `v4` | `v6` |
| `actions/setup-python` | `v4` (test) / `v5` (daily) | `v6` （統一） |
| `actions/cache` | `v4` | `v5` |

対象ファイル:
- `.github/workflows/daily-update.yml`
- `.github/workflows/test-branch.yml`

## 変更理由
GitHub Actions ランナーで Node.js 20 が非推奨化され、2026-06-02 から Node.js 24 が強制デフォルト化、2026-09-16 に Node.js 20 が削除されるため、Node.js 24 対応の最新メジャーに更新する。

参考: 

## 対象外
- `8398a7/action-slack@v3` は依然 Node 20 で稼働中。上流未対応のため別 Issue #122 で追跡する。

## テスト方法
- [x] このブランチで `test-branch.yml` を workflow_dispatch 実行し、全ステップ成功＆ Node.js 20 非推奨アノテーションが出ないことを確認 → [run 24916124950](https://github.com/unsolublesugar/daily-tech-news/actions/runs/24916124950) 成功（42s）
- [x] マージ後、翌朝 JST 7:00 のスケジュール実行（`Daily Tech News Update`）が成功することを確認 → [run 24941808960](https://github.com/unsolublesugar/daily-tech-news/actions/runs/24941808960) 成功（49s）
- [x] 生成ファイル（`daily_news.md` / `index.html` / `rss.xml` / `archives/`）が通常どおり更新されることを確認 → [383c4f9](https://github.com/unsolublesugar/daily-tech-news/commit/383c4f9c2cca81a701222bf00437861342082286)
- [x] Slack 通知が届くことを確認 → ワークフローステップ成功（実配信は別途要確認）