### PR TITLE
🔧 Slack 通知を slackapi/slack-github-action@v3 に移行 (#122)

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -83,26 +83,10 @@ jobs:
           git push
         fi
 
-    - name: Read Slack message
-      id: slack-message
-      run: |
-        if [ -f slack_message.json ]; then
-          # JSONファイルを環境変数経由で安全に読み取り
-          SLACK_CONTENT=$(cat slack_message.json | tr -d '\n')
-          echo "content<<EOF" >> $GITHUB_OUTPUT
-          echo "$SLACK_CONTENT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-        else
-          echo "content<<EOF" >> $GITHUB_OUTPUT
-          echo '{"text":"📰 今日のテックニュース更新完了！","blocks":[{"type":"section","text":{"type":"mrkdwn","text":"最新のテックニュースを更新しました！\n\n🔗 <https://unsolublesugar.github.io/daily-tech-news/|カード表示版を見る>\n📰 <https://github.com/unsolublesugar/daily-tech-news|GitHub リポジトリ>"}}]}' >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-        fi
-
     - name: Notify Slack
-      uses: 8398a7/action-slack@v3
+      uses: slackapi/slack-github-action@v3
       if: success()
       with:
-        status: custom
-        custom_payload: ${{ steps.slack-message.outputs.content }}
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+        webhook-type: incoming-webhook
+        payload-file-path: slack_message.json

--- a/.github/workflows/test-branch.yml
+++ b/.github/workflows/test-branch.yml
@@ -80,10 +80,3 @@ jobs:
         echo ""
         echo "💬 Slack message URLs:"
         cat slack_message.json | grep -o 'https://[^|]*' | head -3 || echo "Slack message check"
-
-    - name: Notify Slack (test)
-      uses: slackapi/slack-github-action@v3
-      with:
-        webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-        webhook-type: incoming-webhook
-        payload-file-path: slack_message.json

--- a/.github/workflows/test-branch.yml
+++ b/.github/workflows/test-branch.yml
@@ -80,3 +80,10 @@ jobs:
         echo ""
         echo "💬 Slack message URLs:"
         cat slack_message.json | grep -o 'https://[^|]*' | head -3 || echo "Slack message check"
+
+    - name: Notify Slack (test)
+      uses: slackapi/slack-github-action@v3
+      with:
+        webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+        webhook-type: incoming-webhook
+        payload-file-path: slack_message.json


### PR DESCRIPTION
Fixes #122

## 変更内容
| 項目 | 変更前 | 変更後 |
|---|---|---|
| Slack 通知アクション | `8398a7/action-slack@v3.19.0` | `slackapi/slack-github-action@v3` |
| Node ランタイム | Node.js 20 | Node.js 24 |
| ペイロード渡し方 | `Read Slack message` step → `custom_payload` | `payload-file-path: slack_message.json` |
| ワークフローステップ数 | 2（Read + Notify） | 1（Notify のみ） |

対象ファイル:
- `.github/workflows/daily-update.yml` — Slack 関連ステップを差し替え＆簡素化
- `.github/workflows/test-branch.yml` — マージ前検証用に `Notify Slack (test)` を追加（検証完了後に[1e5ee5c](https://github.com/unsolublesugar/daily-tech-news/pull/123/commits/1e5ee5c)で削除）

## 変更理由
上流 `8398a7/action-slack` リポジトリが [2026-04-09 にアーカイブ済み](https://github.com/8398a7/action-slack)。Node.js 20 撤去（2026-09-16）までに移行が必須のため、継続メンテが見込める Slack 公式アクションへ置き換える。`fetch_news.py` の `generate_slack_message` が出力する Block Kit 形式 JSON はそのまま新アクションが受け付けるためペイロード生成側は無変更。

## 補足
- 既存の `secrets.SLACK_WEBHOOK_URL` をそのまま流用
- `custom_payload` 経由の bash escape が不要になり、`Read Slack message` ステップを丸ごと削除
- フォールバック JSON（`slack_message.json` 不在時の固定メッセージ）も削除。`fetch_news.py` 実行時に必ず生成されるため不要

## テスト方法
- [x] PR ブランチで `test-branch.yml` を `workflow_dispatch` 実行 → 全ステップ成功＆ Slack チャンネルにテスト通知が1件届くことを確認 → [run 24955233230](https://github.com/unsolublesugar/daily-tech-news/actions/runs/24955233230) 成功（45s）/ ユーザー側で Slack 通知到達確認済み
- [x] Block Kit のレイアウト崩れがないこと → ユーザー側で確認済み
- [x] マージ後、翌朝 JST 7:00 のスケジュール実行（`Daily Tech News Update`）で Slack 通知が従来どおり届くことを確認 → [run 24968282696](https://github.com/unsolublesugar/daily-tech-news/actions/runs/24968282696) 成功（49s）/ ユーザー側で Slack 通知到達確認済み
- [x] Node.js 20 非推奨アノテーションが消失することを確認 → [run 24968282696](https://github.com/unsolublesugar/daily-tech-news/actions/runs/24968282696) のログに `Node.js 20` 関連の deprecation 出力なし

## ロールバック
破損時は revert + push。Slack 通知ステップは `if: success()` で末尾配置のため、失敗してもニュース生成自体には影響なし。