### PR TITLE
✨ カード表示: ハイライト記事を以降のセクションから除外 (#142)

### DIFF
--- a/src/generators/archive_generator.py
+++ b/src/generators/archive_generator.py
@@ -170,15 +170,27 @@ class ArchiveGenerator:
         else:
             highlights_heading = "今日のハイライト"
 
-        html_content = tm.render_media_toc(feed_names)
-        html_content += tm.render_highlights(
-            self.select_highlights(all_entries, mention_counts, now=now),
-            heading=highlights_heading
-        )
+        highlights = self.select_highlights(all_entries, mention_counts, now=now)
+        highlight_links = {item['link'] for item in highlights}
 
+        # ハイライトに出した記事はメディアセクションから外す（ファーストビューとの重複回避）。
+        # 除外してから display_count 件を取るので、表示件数は減らず次の記事が繰り上がる。
+        sections = []
         for feed_name in feed_names:
+            entries = [entry for entry in all_entries[feed_name]
+                       if entry.link not in highlight_links]
+            if entries:
+                sections.append((feed_name, entries[:display_count]))
+
+        if not sections:
+            return tm.render_highlights(highlights, heading=highlights_heading)
+
+        html_content = tm.render_media_toc([feed_name for feed_name, _ in sections])
+        html_content += tm.render_highlights(highlights, heading=highlights_heading)
+
+        for feed_name, entries in sections:
             rows = ''
-            for entry in all_entries[feed_name][:display_count]:
+            for entry in entries:
                 rows += tm.render_article_row(entry, feed_name, now)
             html_content += tm.render_media_section(feed_name, rows)
 


### PR DESCRIPTION
Closes #142

## 変更内容
- `build_articles_tab` でハイライトに選定された記事のURLを集め、メディア別セクションの表示対象から除外
- 除外してから `DISPLAY_PER_MEDIA`（3件）を取るようにしたため、表示件数は減らず次点の記事が繰り上がる
- 除外の結果エントリが0件になったメディアは、セクションもメディア目次チップも出さない（目次チップは実際に出力するセクションから生成）
- index.html / アーカイブHTMLの両方に適用（同じ関数を経由するため）

## 変更理由
ファーストビューの「今日のハイライト」で見た記事が、スクロール後のメディア別セクションにもそのまま再掲されており、重複がノイズになっていたため。

## テスト方法
1. `python3 fetch_news.py` を実行
2. `python3 -m http.server` でローカルサーバを起動し、`index.html` とアーカイブHTMLをブラウザで確認
3. ハイライト3件が以降のセクションに現れないこと、各メディアセクションが3件のままであることを確認

### 確認結果（2026-07-28分）
- ハイライト3件（Zenn / Tech Blog Weekly / はてブ新着）は以降のセクションに出現せず、重複0件
- 10メディアすべてのセクションが3件を維持
- アーカイブHTML（`archives/2026/07/2026-07-28.html`）でも同様に重複0件

⚠️ 生成物（index.html / daily_news.md / rss.xml / archives）は動作確認用に再生成しただけなのでコミットに含めていません。次回のGitHub Actions実行で反映されます。