### PR TITLE
✨ PR表記付き記事を除外 (#146)

### DIFF
--- a/fetch_news.py
+++ b/fetch_news.py
@@ -73,6 +73,11 @@ SEMINAR_BODY_PATTERNS = tuple(re.compile(pattern) for pattern in (
     r'(?:参加|受講|申[しシ]?込み?)(?:登録)?はこちら',
 ))
 
+# タイトルに付くPR表記（広告・タイアップ記事の目印）。
+# 「PRを送る」「PRレビュー」などGitHubのPull Request文脈を巻き込まないよう、
+# 角括弧・隅付き括弧で囲まれた表記だけを対象にする（全角半角・大文字小文字は問わない）。
+PR_TITLE_PATTERN = re.compile(r'[\[［【]\s*(?:PR|ＰＲ)\s*[\]］】]', re.IGNORECASE)
+
 _TRACKING_PARAMS = frozenset({
     "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
     "ref", "fbclid", "gclid",
@@ -163,6 +168,23 @@ def filter_seminar_signup_entries(entries, feed_name):
     excluded_count = len(entries) - len(filtered_entries)
     if excluded_count > 0:
         print(f"Excluded {excluded_count} seminar signup entries from {feed_name}")
+
+    return filtered_entries
+
+
+def is_pr_entry(entry):
+    """タイトルにPR表記（[PR]・［PR］・【PR】）が付いた広告記事かどうかを判定する"""
+    title = re.sub(r'<[^>]+>', '', getattr(entry, 'title', '') or '')
+    return bool(PR_TITLE_PATTERN.search(title))
+
+
+def filter_pr_entries(entries, feed_name):
+    """PR表記付きの広告・タイアップ記事を除外する"""
+    filtered_entries = [entry for entry in entries if not is_pr_entry(entry)]
+
+    excluded_count = len(entries) - len(filtered_entries)
+    if excluded_count > 0:
+        print(f"Excluded {excluded_count} PR entries from {feed_name}")
 
     return filtered_entries
 
@@ -714,6 +736,9 @@ if __name__ == "__main__":
             if domain == 'anond.hatelabo.jp' and name not in ["はてなブックマーク - IT（人気）", "はてなブックマーク - IT（新着）"]:
                 continue
             entries = filter_entries_by_domain(entries, domain, label)
+
+        # PR表記付きの広告・タイアップ記事は全フィードから除外する
+        entries = filter_pr_entries(entries, name)
 
         # セミナー申込ページだけの記事は記事フィードからのみ除外する
         # （イベントフィードのセミナーはイベントタブの正規コンテンツなので残す）


### PR DESCRIPTION
Closes #146

## 変更内容
- `PR_TITLE_PATTERN` を追加し、タイトルのPR表記（`[PR]` / `［PR］` / `【PR】`、全角半角・大文字小文字・前後スペース差異を許容）を判定
- `is_pr_entry()` / `filter_pr_entries()` を追加し、フィード取得直後（既存のEXCLUDED_DOMAINS・セミナー除外と同じ層）で除外
- 適用対象は全フィード（広告記事はイベント・書籍タブでも不要なため）
- 除外時は `Excluded N PR entries from <フィード名>` をログ出力

## 変更理由
自社プロダクトの宣伝・ポジショントーク的な内容が多く、技術記事としての有用性が低いタイアップ広告記事が混ざり込んでいたため。

例（2026-07-29分）: [SaaSにおけるUI開発のよくある課題とその解決方法、教えます［PR］](https://www.publickey1.jp/blog/26/saasuipr.html)

## テスト方法
1. `python3 fetch_news.py` を実行 → `Excluded 1 PR entries from Publickey` が出力され、上記記事が `index.html` / `daily_news.md` / `rss.xml` / アーカイブのいずれからも消えることを確認
2. `python3 -m http.server` でローカル表示を確認（Publickeyセクション自体は他記事で正常表示）
3. 誤除外チェック（判定関数の単体確認）
   - 除外される: `…教えます［PR］` / `【PR】…` / `[PR] …` / `[ PR ] …` / `［ＰＲ］…` / `[pr] …`
   - 除外されない: `PRを送るだけでリポジトリを更新する` / `一人前のエンジニアなら、PRでコメントをもらうな` / `全PRの83%をAIレビューに置き換えた話` / `地域PR動画制作の舞台裏` / `名古屋CV・PRML勉強会` / `…コードレビューからPRDガバナンスへ`

## 補足
生成物（`index.html` / `daily_news.md` / `rss.xml` / `archives/`）は差分に含めていません。マージ後、翌朝JST 7:00の自動実行で該当記事が消えます。