### PR TITLE
🐛 修正: PR表記の除外判定を先頭・末尾に限定 (#148)

### DIFF
--- a/fetch_news.py
+++ b/fetch_news.py
@@ -76,7 +76,16 @@ SEMINAR_BODY_PATTERNS = tuple(re.compile(pattern) for pattern in (
 # タイトルに付くPR表記（広告・タイアップ記事の目印）。
 # 「PRを送る」「PRレビュー」などGitHubのPull Request文脈を巻き込まないよう、
 # 角括弧・隅付き括弧で囲まれた表記だけを対象にする（全角半角・大文字小文字は問わない）。
-PR_TITLE_PATTERN = re.compile(r'[\[［【]\s*(?:PR|ＰＲ)\s*[\]］】]', re.IGNORECASE)
+_PR_MARKER = r'[\[［【]\s*(?:PR|ＰＲ)\s*[\]］】]'
+
+# 実際の広告記事はタイトルの先頭（【PR】…）か末尾（…教えます［PR］）にPR表記が付く。
+# タイトル中間の表記は引用文の一部（例:「AIパートナー「[PR] この製品を…」」）であり
+# 広告記事ではないため、位置を先頭・末尾に限定して誤除外を防ぐ。
+# 末尾側は、はてなブックマーク等が付与する「 | サイト名」の後置を許容する。
+PR_TITLE_PATTERN = re.compile(
+    rf'^\s*{_PR_MARKER}|{_PR_MARKER}\s*(?:[|｜]\s*[^|｜]*)?$',
+    re.IGNORECASE
+)
 
 _TRACKING_PARAMS = frozenset({
     "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",


### PR DESCRIPTION
Fixes #148

## 変更内容
- `PR_TITLE_PATTERN` を先頭アンカー・末尾アンカーの2択に変更（マーカー本体は `_PR_MARKER` に切り出し）
- 末尾側は、はてなブックマーク等が付与する `… ［PR］ | サイト名` の後置を許容

## 変更理由
#146 のフィルタはタイトル中のどこに `[PR]` があってもマッチするため、引用文に `[PR]` を含むだけの通常記事を誤除外していた。

誤除外例（[archives/2025/09/2025-09-27.md](archives/2025/09/2025-09-27.md)）:
```
[2025年9月26日] AIパートナー「[PR] この製品を導入して生活を一新しませんか？」 (週刊AI) | CareNet Engineersのフィード
```

実際の広告記事はタイトルの先頭（`【PR】…`）か末尾（`…教えます［PR］`）に表記が付くため、位置を限定しても除外力は落ちない。

## テスト方法
1. 過去アーカイブ全タイトル（28,940件）に判定を適用 → マッチはPublickey・CodeZineのタイアップ広告17種（延べ83件）のみ。上記の誤除外例は解消
2. `python3 fetch_news.py` → `Excluded 1 PR entries from Publickey`（従来どおり）
3. 判定関数の単体確認
   - 除外される: `…教えます［PR］` / `【PR】…` / `[PR] …` / `[ PR ] …` / `［ＰＲ］…` / `[pr] …` / `…試してみた［PR］ | Publickey`
   - 除外されない: 上記の引用文パターン / `PRを送るだけで…` / `全PRの83%を…` / `名古屋CV・PRML勉強会` / `…PRDガバナンスへ`

## 補足
生成物は差分に含めていません（#147 と同様）。